### PR TITLE
actions: update artifact actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build Falconieri
         run: go build
       - name: Upload Falconieri binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: falconieri
           path: ./falconieri
@@ -25,7 +25,7 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4.1.8
         id: download
         with:
           name: 'falconieri'


### PR DESCRIPTION
Update both actions to v4 major version.
Refer to the migration guide:
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

Previous PR: https://github.com/nethesis/falconieri/pull/7
