### PR TITLE
Add YMCS provider support and client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Supported providers:
 * [Snom](https://service.snom.com/display/wiki/XML-RPC+API)
 * [Gigaset](https://teamwork.gigaset.com/gigawiki/display/GPPPO/Gigaset+Redirect+server)
 * Fanvil (a link to its public documentation was not found)
-* [Yealink](http://support.yealink.com/documentFront/forwardToDocumentDetailPage?documentId=257)
+* [Yealink (legacy provider)](https://support-cdn.yealink.com/attachment/upload/attachment/2019-1-8/5/b6a08cc4-0d6c-4def-b2f4-224b9653c051/Yealink+XML+API+for+RPS-V1.6-ENG.pdf)
+* [YMCS (Yealink Management Cloud Service V4X)](https://support.yealink.com/document-detail/c0966bbacb51405397c55290c2925f65) To use the YMCS provider, you need to ask Yealink to enable `/v2/rps/addDevicesByMac` endpoint for your account.
 
 ## APIs
 
@@ -43,13 +44,24 @@ Example:
 {"url":"https://example.com/"}
 ```
 #### Response
-The API return a HTTP status code `200` with an empty body in case of success
-or a json object in case of error.
-Json  object field:
+The API returns a HTTP status code `200` in case of success.
+
+For providers other than `ymcs`, the response body is empty.
+
+For the `ymcs` provider, the response body is a JSON object:
+* `device_pin`: a string PIN if returned by YMCS, otherwise `null`.
+
+In case of error, the API returns a JSON object.
+JSON object fields:
 * `error`: specific error code.
-* `message`: additional informations (optional).
+* `message`: additional information (optional).
 ##### 200
 The device was configured successfully
+
+YMCS response example:
+```json
+{"device_pin":"123456"}
+```
 
 ##### 400
 Errors codes:
@@ -105,6 +117,12 @@ Gigaset specific:
 
 * `disable_crc` If set to `true` Falconieri don't send the mac address's CRC code, default `false`
 
+YMCS specific:
+
+* `base_url` YMCS API base URL, for example `https://eu-api.ymcs.yealink.com`
+* `client_id` OAuth client ID issued by Yealink
+* `client_secret` OAuth client secret issued by Yealink
+
 
 Example:
 
@@ -115,6 +133,12 @@ Example:
        "user":"user",
        "password": "password",
        "rpc_url": "https://secure-provisioning.snom.com:8083/xmlrpc/",
+       "disable": false
+     },
+     "ymcs": {
+       "base_url": "https://eu-api.ymcs.yealink.com",
+       "client_id": "your-client-id",
+       "client_secret": "your-client-secret",
        "disable": false
      }
 }
@@ -138,10 +162,15 @@ Example:
 * `FANVIL_RPC_URL` The URL for XML-RPC requests of Fanvil provider
 * `FANVIL_DISABLE` Enable/Disable the provider, default `false`
 
-* `YEALINK_USER` Username for access to Yealink provider
-* `YEALINK_PASSWORD` Password for access to Yealink provider
-* `YEALINK_RPC_URL` The URL for XML-RPC requests of Yealink provider
+* `YEALINK_USER` Username for access to Yealink legacy provider
+* `YEALINK_PASSWORD` Password for access to Yealink legacy provider
+* `YEALINK_RPC_URL` The URL for XML-RPC requests of Yealink legacy provider
 * `YEALINK_DISABLE` Enable/Disable the provider, default `false`
+
+* `YMCS_BASE_URL` YMCS API base URL, for example `https://eu-api.ymcs.yealink.com`
+* `YMCS_CLIENT_ID` OAuth client ID issued by Yealink
+* `YMCS_CLIENT_SECRET` OAuth client secret issued by Yealink
+* `YMCS_DISABLE` Enable/Disable the YMCS provider, default `false`
 
 ## Other projects
 

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -41,12 +41,20 @@ type GigasetConf struct {
 	DisableCrc bool `json:"disable_crc"`
 }
 
+type YmcsConf struct {
+	Disable      bool   `json:"disable"`
+	BaseURL      string `json:"base_url"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
 type Configuration struct {
 	Providers struct {
 		Snom    ProviderConf `json:"snom"`
 		Gigaset GigasetConf  `json:"gigaset"`
 		Fanvil  ProviderConf `json:"fanvil"`
 		Yealink ProviderConf `json:"yealink"`
+		Ymcs    YmcsConf     `json:"ymcs"`
 	} `json: "providers"`
 }
 
@@ -183,5 +191,33 @@ func Init(ConfigFilePtr *string) {
 			Config.Providers.Yealink.RpcUrl == "") {
 
 		Config.Providers.Yealink.Disable = true
+	}
+
+	if os.Getenv("YMCS_BASE_URL") != "" {
+		Config.Providers.Ymcs.BaseURL = os.Getenv("YMCS_BASE_URL")
+	}
+
+	if os.Getenv("YMCS_CLIENT_ID") != "" {
+		Config.Providers.Ymcs.ClientID = os.Getenv("YMCS_CLIENT_ID")
+	}
+
+	if os.Getenv("YMCS_CLIENT_SECRET") != "" {
+		Config.Providers.Ymcs.ClientSecret = os.Getenv("YMCS_CLIENT_SECRET")
+	}
+
+	if os.Getenv("YMCS_DISABLE") != "" {
+
+		disable, err := strconv.ParseBool(os.Getenv("YMCS_DISABLE"))
+		if err == nil {
+			Config.Providers.Ymcs.Disable = disable
+		}
+	}
+
+	if !Config.Providers.Ymcs.Disable &&
+		(Config.Providers.Ymcs.ClientID == "" ||
+			Config.Providers.Ymcs.ClientSecret == "" ||
+			Config.Providers.Ymcs.BaseURL == "") {
+
+		Config.Providers.Ymcs.Disable = true
 	}
 }

--- a/deploy/ansible/roles/falconieri/defaults/main.yml
+++ b/deploy/ansible/roles/falconieri/defaults/main.yml
@@ -22,3 +22,8 @@ fanvil_user: user
 fanvil_password: password
 fanvil_rpc_url: http://fdps.fanvil.com/xmlrpc.php
 fanvil_disable: "false"
+
+ymcs_base_url: https://eu-api.ymcs.yealink.com
+ymcs_client_id: client
+ymcs_client_secret: secret
+ymcs_disable: "false"

--- a/deploy/ansible/roles/falconieri/templates/conf.json.tpl
+++ b/deploy/ansible/roles/falconieri/templates/conf.json.tpl
@@ -24,6 +24,12 @@
       "password": "{{ fanvil_password }}",
       "rpc_url": "{{ fanvil_rpc_url }}",
       "disable": {{ fanvil_disable }}
+    },
+    "ymcs": {
+      "base_url": "{{ ymcs_base_url }}",
+      "client_id": "{{ ymcs_client_id }}",
+      "client_secret": "{{ ymcs_client_secret }}",
+      "disable": {{ ymcs_disable }}
     }
   }
 }

--- a/deploy/ansible/roles/falconieri/templates/conf.json.tpl
+++ b/deploy/ansible/roles/falconieri/templates/conf.json.tpl
@@ -12,7 +12,7 @@
       "rpc_url": "{{ yealink_rpc_url }}",
       "disable": {{ yealink_disable }}
     },
-    "giagaset": {
+    "gigaset": {
       "user":"{{ gigaset_user }}",
       "password": "{{ gigaset_password }}",
       "rpc_url": "{{ gigaset_rpc_url }}",

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,37 @@
 module github.com/nethesis/falconieri
 
-go 1.13
+go 1.17
 
 require (
 	github.com/divan/gorilla-xmlrpc v0.0.0-20190926132722-f0686da74fda
 	github.com/gin-gonic/gin v1.9.1
+)
+
+require (
+	github.com/bytedance/sonic v1.9.1 // indirect
+	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.14.0 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gorilla/rpc v1.2.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
+	github.com/leodido/go-urn v1.2.4 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/rogpeppe/go-charset v0.0.0-20190617161244-0dc95cdf6f31 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ugorji/go/codec v1.2.11 // indirect
+	golang.org/x/arch v0.3.0 // indirect
+	golang.org/x/crypto v0.9.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/libs/ymcs/API_MANUAL.md
+++ b/libs/ymcs/API_MANUAL.md
@@ -176,6 +176,8 @@ client.Debug = true
 
 The client always stores the last request/response details in `LastRequest`, `LastRequestBody`, `LastResponse`, and `LastRespBody` (overwritten on every request). When `Debug` is enabled it also emits log messages for token usage and refresh.
 
+**Note on concurrent access**: These debug fields are protected by an internal mutex for thread-safe writes. If you need to read these fields while the client may be processing concurrent requests, you should copy the values immediately after the operation completes to avoid potential races.
+
 #### Custom HTTP Client
 
 Replace the default HTTP client with a custom one:

--- a/libs/ymcs/API_MANUAL.md
+++ b/libs/ymcs/API_MANUAL.md
@@ -1,0 +1,1590 @@
+# Yealink YMCS API Client Library - Technical Manual
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Installation](#installation)
+3. [Package Overview](#package-overview)
+4. [Client Initialization](#client-initialization)
+5. [Authentication](#authentication)
+6. [Device Management](#device-management)
+7. [Data Types](#data-types)
+8. [Error Handling](#error-handling)
+9. [Advanced Usage](#advanced-usage)
+10. [Code Examples](#code-examples)
+
+---
+
+## Introduction
+
+The Yealink YMCS API Client Library provides a comprehensive Go interface for interacting with the Yealink Management Cloud Service (YMCS) API version 2. This library implements OAuth 2.0 authentication with automatic token management and offers a complete set of device management operations.
+
+This library is currently concentrated on the 5.1 RPS Device Management portion of the YMCS specifications, offering robust support for provisioning and managing devices through the RPS endpoints. It implements the OAuth 2.0 client credentials flow with automatic token management.
+
+### Key Features
+
+- Full OAuth 2.0 client credentials flow implementation
+- Automatic token caching and refresh
+- Device lifecycle management (search, add, delete)
+- Device PIN retrieval for provisioning
+- Batch operations support
+- MAC address normalization (supports multiple formats)
+- Thread-safe implementation for concurrent use
+- Comprehensive type definitions
+- Built-in debug capabilities
+
+
+### API Endpoints Reference
+
+The library abstracts the following YMCS API v2 endpoints:
+
+| Operation | Endpoint | HTTP Method | Library Method |
+|-----------|----------|-------------|----------------|
+| Get Token | `/v2/token` | POST | `GetAccessToken()` |
+| Search Devices | `/v2/rps/listDevices` | POST | `SearchDevices()` |
+| Get Device Details | `/v2/rps/devices/{id}` | GET | `GetDeviceDetails()` |
+| Get Device PINs | `/v2/rps/listDevicePins` | POST | `GetDevicePINs()` |
+| Add Device | `/v2/rps/devices` | POST | `AddDevice()` |
+| Add by MAC (Batch) | `/v2/rps/addDevicesByMac` | POST | `AddDevicesByMac()` |
+| Delete Devices | `/v2/rps/delDevices` | POST | `DeleteDevices()` |
+
+### Package Information
+
+- **Package Name**: `ymcs`
+- **Import Path (this repository)**: `github.com/nethesis/falconieri/libs/ymcs`
+- **Go Version**: 1.17 or higher
+- **API Version**: v2
+- **No External Dependencies**: Uses only Go standard library
+
+Note: the client uses `time.Time` millisecond helpers such as `time.Now().UnixMilli()` / `time.UnixMilli()`, which require Go 1.17+.
+
+---
+
+## Installation
+
+### Using Go Modules
+
+Add the library to your project:
+
+```bash
+go get github.com/nethesis/falconieri@latest
+```
+
+### Import Statement
+
+```go
+import "github.com/nethesis/falconieri/libs/ymcs"
+```
+
+---
+
+## Package Overview
+
+The library is organized into the following components:
+
+### Core Components
+
+- **Client**: Main client structure for API interactions
+- **Authentication**: OAuth 2.0 token management
+- **Device Operations**: CRUD operations for device management
+- **Types**: Comprehensive data structures for requests and responses
+
+### File Structure
+
+```
+libs/ymcs/
+├── client.go        # Core client implementation and HTTP request handling
+├── auth.go          # OAuth 2.0 authentication and token management
+├── devices.go       # Device management operations
+├── errors.go        # YMCS error parsing and structured error type
+└── types.go         # Data type definitions
+```
+
+---
+
+## Client Initialization
+
+### Creating a New Client
+
+The `NewClient` function creates a new instance of the Yealink YMCS API client.
+
+#### Function Signature
+
+```go
+func NewClient(baseURL, clientID, clientSecret string) *Client
+```
+
+#### Parameters
+
+- **baseURL** (string): The YMCS API base URL
+  - Europe: `https://eu-api.ymcs.yealink.com`
+  - US: `https://us-api.ymcs.yealink.com`
+  - Custom: Your on-premises YMCS server URL
+  
+- **clientID** (string): OAuth 2.0 client ID provided by Yealink
+
+- **clientSecret** (string): OAuth 2.0 client secret provided by Yealink
+
+#### Returns
+
+- **\*Client**: Pointer to a new Client instance
+
+#### Example
+
+```go
+client := ymcs.NewClient(
+    "https://eu-api.ymcs.yealink.com",
+    "your-client-id",
+    "your-client-secret",
+)
+```
+
+### Client Structure
+
+The Client structure contains the following fields:
+
+```go
+type Client struct {
+    BaseURL      string        // API base URL
+    ClientID     string        // OAuth client ID
+    ClientSecret string        // OAuth client secret
+    HTTPClient   *http.Client  // Underlying HTTP client
+    Debug        bool          // Enable debug logging
+    
+    // Internal fields (managed automatically)
+    accessToken  string        // Cached OAuth token
+    tokenExpiry  time.Time     // Token expiration time
+    
+    // Last request/response (overwritten on each call)
+    LastRequest     *http.Request
+    LastRequestBody string
+    LastResponse    *http.Response
+    LastRespBody    string
+}
+```
+
+### Client Configuration
+
+#### Setting Debug Mode
+
+Enable debug mode to capture detailed request/response information:
+
+```go
+client := ymcs.NewClient(baseURL, clientID, clientSecret)
+client.Debug = true
+```
+
+The client always stores the last request/response details in `LastRequest`, `LastRequestBody`, `LastResponse`, and `LastRespBody` (overwritten on every request). When `Debug` is enabled it also emits log messages for token usage and refresh.
+
+#### Custom HTTP Client
+
+Replace the default HTTP client with a custom one:
+
+```go
+client := ymcs.NewClient(baseURL, clientID, clientSecret)
+client.HTTPClient = &http.Client{
+    Timeout: 60 * time.Second,
+    Transport: customTransport,
+}
+```
+
+---
+
+## Authentication
+
+### Overview
+
+The library implements OAuth 2.0 client credentials flow with automatic token management. Tokens are cached and automatically refreshed when expired.
+
+### GetAccessToken
+
+Retrieves and caches an OAuth 2.0 access token.
+
+#### Function Signature
+
+```go
+func (c *Client) GetAccessToken() (string, error)
+```
+
+#### Returns
+
+- **string**: The access token
+- **error**: Error if authentication fails
+
+#### Behavior
+
+1. Returns cached token if still valid (with 60-second buffer)
+2. Automatically requests new token when expired
+3. Caches token for subsequent requests
+4. Thread-safe token management
+
+#### Example
+
+```go
+token, err := client.GetAccessToken()
+if err != nil {
+    log.Fatalf("Authentication failed: %v", err)
+}
+fmt.Printf("Access token: %s\n", token)
+```
+
+#### Error Conditions
+
+- Invalid credentials (401 Unauthorized)
+- Network connectivity issues
+- Malformed response from server
+- Invalid client ID/secret format
+
+#### Notes
+
+- You typically don't need to call this method directly
+- All device management methods automatically handle authentication
+- Token caching improves performance by reducing authentication requests
+
+---
+
+## Device Management
+
+### SearchDevices
+
+Searches for devices with optional MAC address filtering and pagination support.
+
+#### Function Signature
+
+```go
+func (c *Client) SearchDevices(mac string, skip, limit int, autoCount bool) (*DeviceSearchResponse, error)
+```
+
+#### Parameters
+
+- **mac** (string): MAC address filter (optional, empty string for no filter)
+  - Supports formats: `aa:bb:cc:dd:ee:ff`, `AA-BB-CC-DD-EE-FF`, `aabbccddeeff`
+  - Automatically normalized to lowercase without separators
+  
+- **skip** (int): Number of records to skip (for pagination)
+
+- **limit** (int): Maximum number of records to return
+
+- **autoCount** (bool): Whether to include total count in response
+
+#### Returns
+
+- **\*DeviceSearchResponse**: Search results with device list and metadata
+- **error**: Error if search fails
+
+#### Example
+
+```go
+// Search for specific device
+devices, err := client.SearchDevices("aa:bb:cc:dd:ee:ff", 0, 10, true)
+if err != nil {
+    log.Fatalf("Search failed: %v", err)
+}
+
+fmt.Printf("Found %d devices\n", devices.Total)
+for _, device := range devices.Data {
+    fmt.Printf("MAC: %s, ID: %s\n", device.MAC, device.ID)
+}
+
+// List all devices with pagination
+devices, err := client.SearchDevices("", 0, 100, true)
+if err != nil {
+    log.Fatalf("Search failed: %v", err)
+}
+```
+
+#### Response Structure
+
+The `DeviceSearchResponse` contains:
+
+```go
+type DeviceSearchResponse struct {
+    Skip  int      `json:"skip"`   // Number of skipped records
+    Limit int      `json:"limit"`  // Maximum records returned
+    Total int      `json:"total"`  // Total matching records
+    Data  []Device `json:"data"`   // Array of device objects
+}
+```
+
+---
+
+### GetDeviceDetails
+
+Retrieves detailed information about a specific device by its ID.
+
+#### Function Signature
+
+```go
+func (c *Client) GetDeviceDetails(deviceID string) (*DeviceDetails, error)
+```
+
+#### Parameters
+
+- **deviceID** (string): The unique device identifier (obtained from search results)
+
+#### Returns
+
+- **\*DeviceDetails**: Detailed device information
+- **error**: Error if retrieval fails
+
+#### Example
+
+```go
+details, err := client.GetDeviceDetails("device-id-123")
+if err != nil {
+    log.Fatalf("Failed to get details: %v", err)
+}
+
+fmt.Printf("Device MAC: %s\n", details.MAC)
+if details.SN != nil {
+    fmt.Printf("Serial Number: %s\n", *details.SN)
+}
+if details.UniqueServerURL != nil {
+    fmt.Printf("Server URL: %s\n", *details.UniqueServerURL)
+}
+```
+
+---
+
+### GetDevicePINs
+
+Retrieves PINs for multiple devices in a single request.
+
+#### Function Signature
+
+```go
+func (c *Client) GetDevicePINs(macs []string) ([]DevicePIN, error)
+```
+
+#### Parameters
+
+- **macs** ([]string): Array of MAC addresses
+  - Supports any MAC format (automatically normalized)
+  - No limit on array size specified in API
+
+#### Returns
+
+- **[]DevicePIN**: Array of MAC/PIN pairs
+- **error**: Error if retrieval fails
+
+#### Example
+
+```go
+macs := []string{
+    "aa:bb:cc:dd:ee:01",
+    "aa:bb:cc:dd:ee:02",
+    "aa:bb:cc:dd:ee:03",
+}
+
+pins, err := client.GetDevicePINs(macs)
+if err != nil {
+    log.Fatalf("Failed to get PINs: %v", err)
+}
+
+for _, pin := range pins {
+    fmt.Printf("MAC: %s, PIN: %s\n", pin.MAC, pin.PIN)
+}
+```
+
+---
+
+### GetSingleDevicePIN
+
+Convenience method to retrieve PIN for a single device.
+
+#### Function Signature
+
+```go
+func (c *Client) GetSingleDevicePIN(mac string) (string, error)
+```
+
+#### Parameters
+
+- **mac** (string): MAC address of the device
+
+#### Returns
+
+- **string**: The device PIN (may be an empty string if no PIN is available)
+- **error**: Error if the request fails (authentication, network, or API error)
+
+#### Example
+
+```go
+pin, err := client.GetSingleDevicePIN("aa:bb:cc:dd:ee:ff")
+if err != nil {
+    log.Fatalf("Failed to get PIN: %v", err)
+}
+
+fmt.Printf("Device PIN: %s\n", pin)
+```
+
+#### Error Conditions
+- MAC address invalid
+- Network or authentication errors
+
+---
+
+### AddDevice
+
+Adds a new device to the YMCS system with full metadata support.
+
+#### Function Signature
+
+```go
+func (c *Client) AddDevice(req AddDeviceRequest) (*AddDeviceResponse, error)
+```
+
+#### Parameters
+
+- **req** (AddDeviceRequest): Device information structure
+
+#### AddDeviceRequest Structure
+
+```go
+type AddDeviceRequest struct {
+    MAC             string   `json:"mac"`                      // Required
+    SN              string   `json:"sn"`                       // Required
+    ServerID        *string  `json:"serverId,omitempty"`       // Optional
+    UniqueServerURL *string  `json:"uniqueServerUrl,omitempty"` // Optional
+    AuthName        *string  `json:"authName,omitempty"`       // Optional
+    Password        *string  `json:"password,omitempty"`       // Optional
+    Remark          *string  `json:"remark,omitempty"`         // Optional
+}
+```
+
+#### Returns
+
+- **\*AddDeviceResponse**: Information about the added device
+- **error**: Error if addition fails
+
+#### Example
+
+```go
+// Basic device addition
+req := ymcs.AddDeviceRequest{
+    MAC: "aa:bb:cc:dd:ee:ff",
+    SN:  "SN1234567890",
+}
+
+device, err := client.AddDevice(req)
+if err != nil {
+    log.Fatalf("Failed to add device: %v", err)
+}
+
+fmt.Printf("Device added with ID: %s\n", device.ID)
+
+// Device with provisioning URL
+serverURL := "https://provisioning.example.com"
+remark := "Conference room phone"
+
+req := ymcs.AddDeviceRequest{
+    MAC:             "aa:bb:cc:dd:ee:ff",
+    SN:              "SN1234567890",
+    UniqueServerURL: &serverURL,
+    Remark:          &remark,
+}
+
+device, err := client.AddDevice(req)
+if err != nil {
+    log.Fatalf("Failed to add device: %v", err)
+}
+```
+
+#### Error Conditions
+
+- Device already exists (duplicate MAC or SN)
+- Invalid MAC address format
+- Invalid serial number
+- Missing required fields
+- Authentication or permission errors
+
+---
+
+### AddDevicesByMac
+
+Adds one or more devices by MAC address only, without requiring serial numbers. Supports batch operations.
+
+#### Function Signature
+
+```go
+func (c *Client) AddDevicesByMac(devices []AddDeviceByMacRequest) (*AddDevicesByMacResponse, error)
+```
+
+#### Parameters
+
+- **devices** ([]AddDeviceByMacRequest): Array of device requests (maximum 100)
+
+#### AddDeviceByMacRequest Structure
+
+```go
+type AddDeviceByMacRequest struct {
+    MAC             string   `json:"mac"`                      // Required
+    ServerID        *string  `json:"serverId,omitempty"`       // Optional
+    UniqueServerURL *string  `json:"uniqueServerUrl,omitempty"` // Optional
+    AuthName        *string  `json:"authName,omitempty"`       // Optional
+    Password        *string  `json:"password,omitempty"`       // Optional
+    Remark          *string  `json:"remark,omitempty"`         // Optional
+}
+```
+
+#### Returns
+
+- **\*AddDevicesByMacResponse**: Batch operation results with success/failure counts
+- **error**: Error if request fails
+
+#### Example
+
+```go
+// Batch add multiple devices
+serverURL := "https://provisioning.example.com"
+
+devices := []ymcs.AddDeviceByMacRequest{
+    {
+        MAC:             "aa:bb:cc:dd:ee:01",
+        UniqueServerURL: &serverURL,
+    },
+    {
+        MAC:             "aa:bb:cc:dd:ee:02",
+        UniqueServerURL: &serverURL,
+    },
+    {
+        MAC:             "aa:bb:cc:dd:ee:03",
+        UniqueServerURL: &serverURL,
+    },
+}
+
+result, err := client.AddDevicesByMac(devices)
+if err != nil {
+    log.Fatalf("Batch add failed: %v", err)
+}
+
+fmt.Printf("Total: %d, Success: %d, Failed: %d\n",
+    result.Total, result.SuccessCount, result.FailureCount)
+
+// Handle partial failures
+if len(result.Errors) > 0 {
+    for _, addErr := range result.Errors {
+        fmt.Printf("Failed to add %s: %s\n", addErr.MAC, addErr.ErrorInfo)
+    }
+}
+```
+
+#### Batch Operation Limits
+
+- Maximum 100 devices per request
+- Partial success supported (some devices may succeed while others fail)
+- Individual errors returned in response
+
+---
+
+### AddDeviceByMacSingle
+
+Convenience method to add a single device by MAC address without serial number.
+
+#### Function Signature
+
+```go
+func (c *Client) AddDeviceByMacSingle(mac string, uniqueServerURL *string) (*AddDevicesByMacResponse, error)
+```
+
+#### Parameters
+
+- **mac** (string): Device MAC address
+- **uniqueServerURL** (*string): Provisioning server URL (optional, can be nil)
+
+#### Returns
+
+- **\*AddDevicesByMacResponse**: Operation result
+- **error**: Error if addition fails
+
+#### Example
+
+```go
+serverURL := "https://provisioning.example.com"
+result, err := client.AddDeviceByMacSingle("aa:bb:cc:dd:ee:ff", &serverURL)
+if err != nil {
+    log.Fatalf("Failed to add device: %v", err)
+}
+
+if result.SuccessCount > 0 {
+    fmt.Println("Device added successfully")
+}
+```
+
+---
+
+### DeleteDevices
+
+Deletes one or more devices from the YMCS system.
+
+#### Function Signature
+
+```go
+func (c *Client) DeleteDevices(deviceIdType string, deviceIds []string) (*DeleteDevicesResponse, error)
+```
+
+#### Parameters
+
+- **deviceIdType** (string): Type of identifier used
+  - `"mac"`: Delete by MAC address
+  - `"id"`: Delete by device ID
+  
+- **deviceIds** ([]string): Array of device identifiers
+
+#### Returns
+
+- **\*DeleteDevicesResponse**: Deletion results with success/failure counts
+- **error**: Error if request fails
+
+#### Example
+
+```go
+// Delete by MAC addresses
+macs := []string{
+    "aa:bb:cc:dd:ee:01",
+    "aa:bb:cc:dd:ee:02",
+    "aa:bb:cc:dd:ee:03",
+}
+
+result, err := client.DeleteDevices("mac", macs)
+if err != nil {
+    log.Fatalf("Delete failed: %v", err)
+}
+
+fmt.Printf("Deleted %d of %d devices\n", result.SuccessCount, result.Total)
+
+// Handle errors
+if len(result.Errors) > 0 {
+    for _, delErr := range result.Errors {
+        fmt.Printf("Error on %s: %s\n", delErr.Field, delErr.Msg)
+    }
+}
+
+// Delete by device IDs
+ids := []string{"device-id-1", "device-id-2"}
+result, err := client.DeleteDevices("id", ids)
+```
+
+---
+
+### DeleteDeviceByMAC
+
+Convenience method to delete a single device by MAC address.
+
+#### Function Signature
+
+```go
+func (c *Client) DeleteDeviceByMAC(mac string) (*DeleteDevicesResponse, error)
+```
+
+#### Parameters
+
+- **mac** (string): Device MAC address
+
+#### Returns
+
+- **\*DeleteDevicesResponse**: Deletion result
+- **error**: Error if deletion fails
+
+#### Example
+
+```go
+result, err := client.DeleteDeviceByMAC("aa:bb:cc:dd:ee:ff")
+if err != nil {
+    log.Fatalf("Delete failed: %v", err)
+}
+
+if result.SuccessCount > 0 {
+    fmt.Println("Device deleted successfully")
+}
+```
+
+---
+
+### DeleteDeviceByID
+
+Convenience method to delete a single device by its ID.
+
+#### Function Signature
+
+```go
+func (c *Client) DeleteDeviceByID(deviceID string) (*DeleteDevicesResponse, error)
+```
+
+#### Parameters
+
+- **deviceID** (string): Device identifier
+
+#### Returns
+
+- **\*DeleteDevicesResponse**: Deletion result
+- **error**: Error if deletion fails
+
+#### Example
+
+```go
+result, err := client.DeleteDeviceByID("device-id-123")
+if err != nil {
+    log.Fatalf("Delete failed: %v", err)
+}
+
+if result.SuccessCount > 0 {
+    fmt.Println("Device deleted successfully")
+}
+```
+
+---
+
+## Data Types
+
+### Device
+
+Represents a device in the YMCS system.
+
+```go
+type Device struct {
+    ID              string  `json:"id"`
+    MAC             string  `json:"mac"`
+    SN              *string `json:"sn"`
+    ServerID        *string `json:"serverId"`
+    ServerName      *string `json:"serverName"`
+    ServerURL       *string `json:"serverUrl"`
+    UniqueServerURL *string `json:"uniqueServerUrl"`
+    IPAddress       *string `json:"ipAddress"`
+    Remark          *string `json:"remark"`
+    DateRegistered  *int64  `json:"dateRegistered"`   // Unix timestamp (milliseconds)
+    LastConnected   *int64  `json:"lastConnected"`    // Unix timestamp (milliseconds)
+}
+```
+
+#### Field Descriptions
+
+- **ID**: Unique device identifier assigned by YMCS
+- **MAC**: Device MAC address (normalized format: lowercase, no separators)
+- **SN**: Serial number (nil if not provided)
+- **ServerID**: Provisioning server identifier
+- **ServerName**: Provisioning server name
+- **ServerURL**: Provisioning server URL
+- **UniqueServerURL**: Device-specific provisioning URL
+- **IPAddress**: Last known IP address
+- **Remark**: User-defined note or description
+- **DateRegistered**: Registration timestamp in milliseconds since Unix epoch
+- **LastConnected**: Last connection timestamp in milliseconds since Unix epoch
+
+#### Usage Example
+
+```go
+devices, _ := client.SearchDevices("", 0, 10, true)
+for _, device := range devices.Data {
+    fmt.Printf("Device ID: %s\n", device.ID)
+    fmt.Printf("MAC: %s\n", device.MAC)
+    
+    // Check optional fields
+    if device.SN != nil {
+        fmt.Printf("SN: %s\n", *device.SN)
+    }
+    
+    if device.DateRegistered != nil {
+        regTime := time.UnixMilli(*device.DateRegistered)
+        fmt.Printf("Registered: %s\n", regTime.Format("2006-01-02 15:04:05"))
+    }
+}
+```
+
+---
+
+### DeviceDetails
+
+Extended device information including authentication details.
+
+```go
+type DeviceDetails struct {
+    Device                // Embedded Device struct
+    AuthName *string `json:"authName"`
+}
+```
+
+#### Additional Fields
+
+- **AuthName**: Authentication username for device provisioning
+
+---
+
+### DevicePIN
+
+Device PIN information for provisioning.
+
+```go
+type DevicePIN struct {
+    MAC string `json:"mac"`
+    PIN string `json:"pin"`
+}
+```
+
+---
+
+### TokenResponse
+
+OAuth 2.0 token response structure.
+
+```go
+type TokenResponse struct {
+    AccessToken string `json:"access_token"`
+    TokenType   string `json:"token_type"`
+    ExpiresIn   int    `json:"expires_in"`  // Seconds until expiration
+}
+```
+
+---
+
+### AddDeviceResponse
+
+Response from adding a device.
+
+```go
+type AddDeviceResponse struct {
+    ID              string  `json:"id"`
+    MAC             string  `json:"mac"`
+    SN              string  `json:"sn"`
+    ServerID        *string `json:"serverId,omitempty"`
+    UniqueServerURL *string `json:"uniqueServerUrl,omitempty"`
+    AuthName        *string `json:"authName,omitempty"`
+    Remark          *string `json:"remark,omitempty"`
+}
+```
+
+---
+
+### AddDevicesByMacResponse
+
+Response from batch add operations.
+
+```go
+type AddDevicesByMacResponse struct {
+    Total        int        `json:"total"`         // Total devices in request
+    SuccessCount int        `json:"successCount"`  // Number successfully added
+    FailureCount int        `json:"failureCount"`  // Number that failed
+    Errors       []AddError `json:"errors"`        // Details of failures
+}
+```
+
+#### AddError Structure
+
+```go
+type AddError struct {
+    MAC       string `json:"mac"`
+    SN        string `json:"sn"`
+    ErrorInfo string `json:"errorInfo"`
+}
+```
+
+---
+
+### DeleteDevicesResponse
+
+Response from delete operations.
+
+```go
+type DeleteDevicesResponse struct {
+    Total        int       `json:"total"`         // Total devices in request
+    SuccessCount int       `json:"successCount"`  // Number successfully deleted
+    FailureCount int       `json:"failureCount"`  // Number that failed
+    Errors       []OpError `json:"errors"`        // Details of failures
+}
+```
+
+#### OpError Structure
+
+```go
+type OpError struct {
+    Field string `json:"field"`
+    Msg   string `json:"msg"`
+}
+```
+
+---
+
+## Error Handling
+
+### Error Types
+
+All methods return standard Go errors.
+
+When the YMCS API returns a JSON error payload, the client returns an `APIError` (see `errors.go`) enriched with:
+
+- HTTP status code (`HTTPStatus`)
+- YMCS `code` (when provided)
+- OAuth `error` (when provided)
+- `requestId` (when provided)
+- a best-effort `FriendlyMessage` for known error codes
+
+When the response body is not a YMCS JSON error payload, the client falls back to a generic error that still includes the HTTP status code and raw body.
+
+#### Common Error Pattern (with inspection)
+
+```go
+import (
+    "errors"
+    "log"
+
+    "github.com/nethesis/falconieri/libs/ymcs"
+)
+
+devices, err := client.SearchDevices("aa:bb:cc:dd:ee:ff", 0, 10, true)
+if err != nil {
+    var apiErr ymcs.APIError
+    if errors.As(err, &apiErr) {
+        log.Printf("YMCS error: status=%d code=%s requestId=%s message=%s",
+            apiErr.HTTPStatus, apiErr.Code, apiErr.RequestID, apiErr.Message)
+        return
+    }
+    log.Printf("request failed: %v", err)
+    return
+}
+_ = devices
+```
+
+### Batch Operation Error Handling
+
+Batch operations support partial success:
+
+```go
+result, err := client.AddDevicesByMac(devices)
+if err != nil {
+    log.Fatalf("Request failed: %v", err)
+}
+
+// Even if err is nil, check for partial failures
+if result.FailureCount > 0 {
+    for _, addErr := range result.Errors {
+        log.Printf("Failed to add %s: %s", addErr.MAC, addErr.ErrorInfo)
+    }
+}
+
+// Process successful additions
+if result.SuccessCount > 0 {
+    log.Printf("Successfully added %d devices", result.SuccessCount)
+}
+```
+
+### Network Error Handling
+
+Network-related errors are wrapped with context:
+
+```go
+devices, err := client.SearchDevices("", 0, 10, true)
+if err != nil {
+    // Could be network timeout, DNS failure, connection refused, etc.
+    log.Printf("Network error: %v", err)
+    // Implement retry logic if needed
+}
+```
+
+---
+
+## Advanced Usage
+
+### MAC Address Normalization
+
+The library automatically normalizes MAC addresses to lowercase without separators.
+
+#### Supported Input Formats
+
+```go
+// All these formats are equivalent:
+client.SearchDevices("AA:BB:CC:DD:EE:FF", 0, 10, true)
+client.SearchDevices("aa:bb:cc:dd:ee:ff", 0, 10, true)
+client.SearchDevices("AA-BB-CC-DD-EE-FF", 0, 10, true)
+client.SearchDevices("aabbccddeeff", 0, 10, true)
+
+// All normalized to: "aabbccddeeff"
+```
+
+### Pagination
+
+Implement pagination for large device lists:
+
+```go
+func getAllDevices(client *ymcs.Client) ([]ymcs.Device, error) {
+    var allDevices []ymcs.Device
+    skip := 0
+    limit := 100
+
+    for {
+        result, err := client.SearchDevices("", skip, limit, true)
+        if err != nil {
+            return nil, err
+        }
+
+        allDevices = append(allDevices, result.Data...)
+
+        // Check if we've retrieved all devices
+        if skip+len(result.Data) >= result.Total {
+            break
+        }
+
+        skip += limit
+    }
+
+    return allDevices, nil
+}
+```
+
+### Concurrent Operations
+
+The client is safe for concurrent use:
+
+```go
+func processDevicesConcurrently(client *ymcs.Client, macs []string) {
+    var wg sync.WaitGroup
+    results := make(chan string, len(macs))
+
+    for _, mac := range macs {
+        wg.Add(1)
+        go func(m string) {
+            defer wg.Done()
+
+            pin, err := client.GetSingleDevicePIN(m)
+            if err != nil {
+                results <- fmt.Sprintf("Error for %s: %v", m, err)
+                return
+            }
+
+            results <- fmt.Sprintf("%s: %s", m, pin)
+        }(mac)
+    }
+
+    wg.Wait()
+    close(results)
+
+    for result := range results {
+        fmt.Println(result)
+    }
+}
+```
+
+### Custom HTTP Client Configuration
+
+Configure timeouts, proxies, and TLS settings:
+
+```go
+import (
+    "crypto/tls"
+    "net/http"
+    "net/url"
+    "time"
+)
+
+// Create custom transport
+proxyURL, _ := url.Parse("http://proxy.example.com:8080")
+transport := &http.Transport{
+    Proxy: http.ProxyURL(proxyURL),
+    TLSClientConfig: &tls.Config{
+        InsecureSkipVerify: false,
+    },
+    MaxIdleConns:        100,
+    MaxIdleConnsPerHost: 10,
+    IdleConnTimeout:     90 * time.Second,
+}
+
+// Create custom HTTP client
+httpClient := &http.Client{
+    Timeout:   60 * time.Second,
+    Transport: transport,
+}
+
+// Use with YMCS client
+client := ymcs.NewClient(baseURL, clientID, clientSecret)
+client.HTTPClient = httpClient
+```
+
+### Debug Mode for Troubleshooting
+
+Enable debug mode to capture request/response details:
+
+```go
+client := ymcs.NewClient(baseURL, clientID, clientSecret)
+client.Debug = true
+
+_, err := client.SearchDevices("aa:bb:cc:dd:ee:ff", 0, 10, true)
+if err != nil {
+    // Inspect last request
+    if client.LastRequest != nil {
+        fmt.Printf("Request URL: %s\n", client.LastRequest.URL)
+        fmt.Printf("Request Method: %s\n", client.LastRequest.Method)
+        fmt.Printf("Request Body: %s\n", client.LastRequestBody)
+    }
+
+    // Inspect last response
+    if client.LastResponse != nil {
+        fmt.Printf("Response Status: %s\n", client.LastResponse.Status)
+        fmt.Printf("Response Body: %s\n", client.LastRespBody)
+    }
+}
+```
+
+### Device Lifecycle Management
+
+Complete device lifecycle example:
+
+```go
+func manageDeviceLifecycle(client *ymcs.Client, mac, sn string) error {
+    // 1. Check if device exists
+    devices, err := client.SearchDevices(mac, 0, 1, true)
+    if err != nil {
+        return fmt.Errorf("search failed: %w", err)
+    }
+
+    // 2. Delete if exists
+    if devices.Total > 0 {
+        fmt.Println("Device exists, deleting...")
+        _, err := client.DeleteDeviceByMAC(mac)
+        if err != nil {
+            return fmt.Errorf("delete failed: %w", err)
+        }
+        time.Sleep(1 * time.Second) // Allow propagation
+    }
+
+    // 3. Add device
+    serverURL := "https://provisioning.example.com"
+    req := ymcs.AddDeviceRequest{
+        MAC:             mac,
+        SN:              sn,
+        UniqueServerURL: &serverURL,
+    }
+
+    device, err := client.AddDevice(req)
+    if err != nil {
+        return fmt.Errorf("add failed: %w", err)
+    }
+
+    fmt.Printf("Device added: %s\n", device.ID)
+
+    // 4. Get device PIN
+    pin, err := client.GetSingleDevicePIN(mac)
+    if err != nil {
+        return fmt.Errorf("get PIN failed: %w", err)
+    }
+
+    fmt.Printf("Device PIN: %s\n", pin)
+
+    // 5. Verify device details
+    details, err := client.GetDeviceDetails(device.ID)
+    if err != nil {
+        return fmt.Errorf("get details failed: %w", err)
+    }
+
+    fmt.Printf("Device configured: %+v\n", details)
+
+    return nil
+}
+```
+
+---
+
+## Code Examples
+
+### Example 1: Basic Device Search
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/nethesis/falconieri/libs/ymcs"
+)
+
+func main() {
+    // Create client
+    client := ymcs.NewClient(
+        "https://eu-api.ymcs.yealink.com",
+        "your-client-id",
+        "your-client-secret",
+    )
+
+    // Search for devices
+    devices, err := client.SearchDevices("", 0, 10, true)
+    if err != nil {
+        log.Fatalf("Search failed: %v", err)
+    }
+
+    fmt.Printf("Found %d devices\n", devices.Total)
+    for i, device := range devices.Data {
+        fmt.Printf("%d. MAC: %s, ID: %s\n", i+1, device.MAC, device.ID)
+    }
+}
+```
+
+### Example 2: Add Device with Provisioning
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/nethesis/falconieri/libs/ymcs"
+)
+
+func main() {
+    client := ymcs.NewClient(
+        "https://eu-api.ymcs.yealink.com",
+        "your-client-id",
+        "your-client-secret",
+    )
+
+    // Prepare device configuration
+    serverURL := "https://provisioning.example.com"
+    remark := "Reception desk phone"
+    authName := "admin"
+    password := "secret123"
+
+    req := ymcs.AddDeviceRequest{
+        MAC:             "aa:bb:cc:dd:ee:ff",
+        SN:              "SN1234567890",
+        UniqueServerURL: &serverURL,
+        Remark:          &remark,
+        AuthName:        &authName,
+        Password:        &password,
+    }
+
+    // Add device
+    device, err := client.AddDevice(req)
+    if err != nil {
+        log.Fatalf("Failed to add device: %v", err)
+    }
+
+    fmt.Printf("Device added successfully!\n")
+    fmt.Printf("ID: %s\n", device.ID)
+    fmt.Printf("MAC: %s\n", device.MAC)
+    fmt.Printf("SN: %s\n", device.SN)
+
+    // Get device PIN
+    pin, err := client.GetSingleDevicePIN(device.MAC)
+    if err != nil {
+        log.Fatalf("Failed to get PIN: %v", err)
+    }
+
+    fmt.Printf("PIN: %s\n", pin)
+}
+```
+
+### Example 3: Batch Device Addition
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/nethesis/falconieri/libs/ymcs"
+)
+
+func main() {
+    client := ymcs.NewClient(
+        "https://eu-api.ymcs.yealink.com",
+        "your-client-id",
+        "your-client-secret",
+    )
+
+    serverURL := "https://provisioning.example.com"
+
+    // Prepare batch of devices
+    devices := []ymcs.AddDeviceByMacRequest{
+        {MAC: "aa:bb:cc:dd:ee:01", UniqueServerURL: &serverURL},
+        {MAC: "aa:bb:cc:dd:ee:02", UniqueServerURL: &serverURL},
+        {MAC: "aa:bb:cc:dd:ee:03", UniqueServerURL: &serverURL},
+        {MAC: "aa:bb:cc:dd:ee:04", UniqueServerURL: &serverURL},
+        {MAC: "aa:bb:cc:dd:ee:05", UniqueServerURL: &serverURL},
+    }
+
+    // Add devices
+    result, err := client.AddDevicesByMac(devices)
+    if err != nil {
+        log.Fatalf("Batch add failed: %v", err)
+    }
+
+    fmt.Printf("Batch Operation Results:\n")
+    fmt.Printf("Total: %d\n", result.Total)
+    fmt.Printf("Success: %d\n", result.SuccessCount)
+    fmt.Printf("Failed: %d\n", result.FailureCount)
+
+    // Report errors
+    if len(result.Errors) > 0 {
+        fmt.Println("\nErrors:")
+        for _, addErr := range result.Errors {
+            fmt.Printf("  %s: %s\n", addErr.MAC, addErr.ErrorInfo)
+        }
+    }
+}
+```
+
+### Example 4: Complete Device Management
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "time"
+
+    "github.com/nethesis/falconieri/libs/ymcs"
+)
+
+func main() {
+    client := ymcs.NewClient(
+        "https://eu-api.ymcs.yealink.com",
+        "your-client-id",
+        "your-client-secret",
+    )
+
+    mac := "aa:bb:cc:dd:ee:ff"
+    sn := "SN1234567890"
+
+    // Step 1: Search for existing device
+    fmt.Println("Searching for existing device...")
+    devices, err := client.SearchDevices(mac, 0, 1, true)
+    if err != nil {
+        log.Fatalf("Search failed: %v", err)
+    }
+
+    // Step 2: Delete if exists
+    if devices.Total > 0 {
+        fmt.Printf("Found existing device (ID: %s), deleting...\n", devices.Data[0].ID)
+        _, err := client.DeleteDeviceByMAC(mac)
+        if err != nil {
+            log.Printf("Warning: Delete failed: %v", err)
+        } else {
+            fmt.Println("Device deleted, waiting for propagation...")
+            time.Sleep(2 * time.Second)
+        }
+    }
+
+    // Step 3: Add device
+    fmt.Println("Adding device...")
+    serverURL := "https://provisioning.example.com"
+    req := ymcs.AddDeviceRequest{
+        MAC:             mac,
+        SN:              sn,
+        UniqueServerURL: &serverURL,
+    }
+
+    device, err := client.AddDevice(req)
+    if err != nil {
+        log.Fatalf("Add failed: %v", err)
+    }
+    fmt.Printf("Device added with ID: %s\n", device.ID)
+
+    // Step 4: Get device details
+    fmt.Println("Retrieving device details...")
+    details, err := client.GetDeviceDetails(device.ID)
+    if err != nil {
+        log.Fatalf("Get details failed: %v", err)
+    }
+
+    fmt.Printf("Device Details:\n")
+    fmt.Printf("  MAC: %s\n", details.MAC)
+    if details.SN != nil {
+        fmt.Printf("  SN: %s\n", *details.SN)
+    }
+    if details.UniqueServerURL != nil {
+        fmt.Printf("  Server URL: %s\n", *details.UniqueServerURL)
+    }
+
+    // Step 5: Get device PIN
+    fmt.Println("Retrieving device PIN...")
+    pin, err := client.GetSingleDevicePIN(mac)
+    if err != nil {
+        log.Fatalf("Get PIN failed: %v", err)
+    }
+    fmt.Printf("Device PIN: %s\n", pin)
+
+    fmt.Println("\nDevice management completed successfully!")
+}
+```
+
+### Example 5: Error Handling and Retry Logic
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "time"
+
+    "github.com/nethesis/falconieri/libs/ymcs"
+)
+
+func searchWithRetry(client *ymcs.Client, mac string, maxRetries int) (*ymcs.DeviceSearchResponse, error) {
+    var lastErr error
+
+    for attempt := 1; attempt <= maxRetries; attempt++ {
+        devices, err := client.SearchDevices(mac, 0, 10, true)
+        if err == nil {
+            return devices, nil
+        }
+
+        lastErr = err
+        if attempt < maxRetries {
+            waitTime := time.Duration(attempt) * time.Second
+            fmt.Printf("Attempt %d failed: %v. Retrying in %v...\n", attempt, err, waitTime)
+            time.Sleep(waitTime)
+        }
+    }
+
+    return nil, fmt.Errorf("all %d attempts failed, last error: %w", maxRetries, lastErr)
+}
+
+func main() {
+    client := ymcs.NewClient(
+        "https://eu-api.ymcs.yealink.com",
+        "your-client-id",
+        "your-client-secret",
+    )
+
+    devices, err := searchWithRetry(client, "aa:bb:cc:dd:ee:ff", 3)
+    if err != nil {
+        log.Fatalf("Search failed after retries: %v", err)
+    }
+
+    fmt.Printf("Found %d devices\n", devices.Total)
+}
+```
+
+### Example 6: Working with Timestamps
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "time"
+
+    "github.com/nethesis/falconieri/libs/ymcs"
+)
+
+func main() {
+    client := ymcs.NewClient(
+        "https://eu-api.ymcs.yealink.com",
+        "your-client-id",
+        "your-client-secret",
+    )
+
+    devices, err := client.SearchDevices("", 0, 10, true)
+    if err != nil {
+        log.Fatalf("Search failed: %v", err)
+    }
+
+    for _, device := range devices.Data {
+        fmt.Printf("Device: %s\n", device.MAC)
+
+        if device.DateRegistered != nil {
+            regTime := time.UnixMilli(*device.DateRegistered)
+            fmt.Printf("  Registered: %s\n", regTime.Format("2006-01-02 15:04:05"))
+
+            // Calculate age
+            age := time.Since(regTime)
+            fmt.Printf("  Age: %.0f days\n", age.Hours()/24)
+        }
+
+        if device.LastConnected != nil {
+            lastTime := time.UnixMilli(*device.LastConnected)
+            fmt.Printf("  Last seen: %s\n", lastTime.Format("2006-01-02 15:04:05"))
+
+            // Check if device is active
+            if time.Since(lastTime) < 24*time.Hour {
+                fmt.Println("  Status: Active (connected within 24h)")
+            } else {
+                fmt.Println("  Status: Inactive")
+            }
+        }
+
+        fmt.Println()
+    }
+}
+```
+
+---
+
+## Best Practices
+
+### Token Management
+
+- Do not manually manage tokens; the client handles this automatically
+- Token caching reduces authentication overhead
+- Token refresh happens automatically with 60-second safety buffer
+
+### Error Handling
+
+- Always check for errors from API calls
+- Use error wrapping for additional context
+- Handle partial failures in batch operations
+- Implement retry logic for transient network errors
+
+### MAC Address Handling
+
+- Use any convenient MAC format; normalization is automatic
+- Store MACs in your preferred format
+- The library ensures consistency with the API
+
+### Resource Management
+
+- Reuse client instances when possible
+- The client is thread-safe for concurrent operations
+- HTTP connections are pooled and reused automatically
+
+### Batch Operations
+
+- Use batch operations for multiple devices to reduce API calls
+- Respect the 100-device limit per batch request
+- Always check FailureCount and Errors in batch responses
+- Implement partial retry logic for failed items
+
+### Production Considerations
+
+- Configure appropriate HTTP timeouts for your network environment
+- Implement logging for audit trails
+- Use debug mode during development and troubleshooting
+- Consider rate limiting if making many concurrent requests
+- Store credentials securely (environment variables, secret managers)
+
+---
+
+## Thread Safety
+
+The client is designed for concurrent use:
+
+- Token management is handled internally with proper synchronization
+- Multiple goroutines can safely call client methods simultaneously
+- HTTP client connection pooling is managed automatically
+- No external synchronization required when using the client
+
+---
+
+## Performance Considerations
+
+### Connection Pooling
+
+The default HTTP client uses connection pooling:
+- Default timeout: 30 seconds
+- Connections are reused across requests
+- Customize via `client.HTTPClient` if needed
+
+### Token Caching
+
+- Tokens are cached until expiration
+- Automatic refresh reduces authentication overhead
+- No token refresh on every request
+
+### Batch Operations
+
+- Use batch operations to reduce API calls
+- Network round-trips are minimized
+- Partial failures are handled gracefully

--- a/libs/ymcs/auth.go
+++ b/libs/ymcs/auth.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+// Package ymcs provides a client for the Yealink YMCS API with OAuth 2.0 authentication
+package ymcs
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+// GetAccessToken retrieves and caches an OAuth 2.0 access token.
+// It uses the client credentials flow and automatically handles token caching
+// and refresh when the token expires.
+func (c *Client) GetAccessToken() (string, error) {
+	// Return cached token if still valid
+	if c.accessToken != "" && time.Now().Before(c.tokenExpiry) {
+		if c.Debug {
+			log.Printf("[YMCS] Using cached access token")
+		}
+		return c.accessToken, nil
+	}
+
+	if c.Debug {
+		log.Printf("[YMCS] Requesting new access token from %s/v2/token", c.BaseURL)
+	}
+
+	// Create Basic Auth credentials
+	credentials := fmt.Sprintf("%s:%s", c.ClientID, c.ClientSecret)
+	encodedCreds := base64.StdEncoding.EncodeToString([]byte(credentials))
+
+	// Prepare request
+	requestBody := map[string]string{
+		"grant_type": "client_credentials",
+	}
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v2/token", c.BaseURL)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Add headers
+	nonce, err := c.getNonce()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Basic "+encodedCreds)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("timestamp", c.getTimestamp())
+	req.Header.Set("nonce", nonce)
+
+	// Store request for debugging
+	c.LastRequest = req
+	c.LastRequestBody = string(jsonData)
+
+	// Send request
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Store response for debugging
+	c.LastResponse = resp
+
+	// Read response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+	c.LastRespBody = string(respBody)
+
+	if resp.StatusCode != http.StatusOK {
+		return "", parseAPIError(resp.StatusCode, respBody)
+	}
+
+	// Parse response
+	var tokenResp TokenResponse
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// Cache token
+	c.accessToken = tokenResp.AccessToken
+	// Set expiry with 60 second buffer
+	c.tokenExpiry = time.Now().Add(time.Duration(tokenResp.ExpiresIn-60) * time.Second)
+
+	return c.accessToken, nil
+}

--- a/libs/ymcs/auth.go
+++ b/libs/ymcs/auth.go
@@ -38,6 +38,10 @@ import (
 // It uses the client credentials flow and automatically handles token caching
 // and refresh when the token expires.
 func (c *Client) GetAccessToken() (string, error) {
+	// serialized access to token cache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	// Return cached token if still valid
 	if c.accessToken != "" && time.Now().Before(c.tokenExpiry) {
 		if c.Debug {

--- a/libs/ymcs/auth.go
+++ b/libs/ymcs/auth.go
@@ -86,8 +86,10 @@ func (c *Client) GetAccessToken() (string, error) {
 	req.Header.Set("nonce", nonce)
 
 	// Store request for debugging
+	c.debugMu.Lock()
 	c.LastRequest = req
 	c.LastRequestBody = string(jsonData)
+	c.debugMu.Unlock()
 
 	// Send request
 	resp, err := c.HTTPClient.Do(req)
@@ -97,14 +99,18 @@ func (c *Client) GetAccessToken() (string, error) {
 	defer resp.Body.Close()
 
 	// Store response for debugging
+	c.debugMu.Lock()
 	c.LastResponse = resp
+	c.debugMu.Unlock()
 
 	// Read response body
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
+	c.debugMu.Lock()
 	c.LastRespBody = string(respBody)
+	c.debugMu.Unlock()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", parseAPIError(resp.StatusCode, respBody)

--- a/libs/ymcs/client.go
+++ b/libs/ymcs/client.go
@@ -32,6 +32,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -44,6 +45,7 @@ type Client struct {
 	Debug        bool // Enable debug logging
 
 	// Token management
+	mu          sync.Mutex // Protects accessToken and tokenExpiry
 	accessToken string
 	tokenExpiry time.Time
 

--- a/libs/ymcs/client.go
+++ b/libs/ymcs/client.go
@@ -50,6 +50,7 @@ type Client struct {
 	tokenExpiry time.Time
 
 	// Last request/response for debugging
+	debugMu         sync.Mutex // Protects debug fields below
 	LastRequest     *http.Request
 	LastRequestBody string
 	LastResponse    *http.Response
@@ -108,8 +109,10 @@ func (c *Client) makeRequest(method, endpoint string, body interface{}) (*http.R
 	}
 
 	// Store request for debugging
+	c.debugMu.Lock()
 	c.LastRequest = req
 	c.LastRequestBody = requestBodyStr
+	c.debugMu.Unlock()
 
 	// Add headers
 	nonce, err := c.getNonce()
@@ -130,14 +133,18 @@ func (c *Client) makeRequest(method, endpoint string, body interface{}) (*http.R
 	}
 
 	// Store response for debugging
+	c.debugMu.Lock()
 	c.LastResponse = resp
+	c.debugMu.Unlock()
 
 	// Read response body for logging
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
+	c.debugMu.Lock()
 	c.LastRespBody = string(bodyBytes)
+	c.debugMu.Unlock()
 
 	// Recreate response body reader
 	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))

--- a/libs/ymcs/client.go
+++ b/libs/ymcs/client.go
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+// Package ymcs provides a client for the Yealink YMCS API with OAuth 2.0 authentication
+package ymcs
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client represents a Yealink YMCS API client
+type Client struct {
+	BaseURL      string
+	ClientID     string
+	ClientSecret string
+	HTTPClient   *http.Client
+	Debug        bool // Enable debug logging
+
+	// Token management
+	accessToken string
+	tokenExpiry time.Time
+
+	// Last request/response for debugging
+	LastRequest     *http.Request
+	LastRequestBody string
+	LastResponse    *http.Response
+	LastRespBody    string
+}
+
+// NewClient creates a new Yealink YMCS API client
+func NewClient(baseURL, clientID, clientSecret string) *Client {
+	return &Client{
+		BaseURL:      strings.TrimSuffix(baseURL, "/"),
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		HTTPClient:   &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// getTimestamp returns current timestamp in milliseconds
+func (c *Client) getTimestamp() string {
+	return fmt.Sprintf("%d", time.Now().UnixMilli())
+}
+
+// getNonce generates a random 32-character hex string
+func (c *Client) getNonce() (string, error) {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+// makeRequest makes an authenticated API request
+func (c *Client) makeRequest(method, endpoint string, body interface{}) (*http.Response, error) {
+	// Get valid token
+	token, err := c.GetAccessToken()
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare request body
+	var reqBody io.Reader
+	var requestBodyStr string
+	if body != nil {
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		requestBodyStr = string(jsonData)
+		reqBody = bytes.NewBuffer(jsonData)
+	}
+
+	// Create request
+	url := fmt.Sprintf("%s%s", c.BaseURL, endpoint)
+	req, err := http.NewRequest(method, url, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Store request for debugging
+	c.LastRequest = req
+	c.LastRequestBody = requestBodyStr
+
+	// Add headers
+	nonce, err := c.getNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("timestamp", c.getTimestamp())
+	req.Header.Set("nonce", nonce)
+
+	// Send request
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	// Store response for debugging
+	c.LastResponse = resp
+
+	// Read response body for logging
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	c.LastRespBody = string(bodyBytes)
+
+	// Recreate response body reader
+	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	return resp, nil
+}
+
+// cleanMAC removes separators from MAC address and converts to lowercase
+func cleanMAC(mac string) string {
+	mac = strings.ReplaceAll(mac, ":", "")
+	mac = strings.ReplaceAll(mac, "-", "")
+	return strings.ToLower(mac)
+}

--- a/libs/ymcs/devices.go
+++ b/libs/ymcs/devices.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+// Package ymcs provides a client for the Yealink YMCS API with OAuth 2.0 authentication
+package ymcs
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// SearchDevices searches for devices with optional MAC filter.
+// Use skip and limit for pagination, and set autoCount to true to get total count.
+func (c *Client) SearchDevices(mac string, skip, limit int, autoCount bool) (*DeviceSearchResponse, error) {
+	req := DeviceSearchRequest{
+		Skip:      skip,
+		Limit:     limit,
+		AutoCount: autoCount,
+	}
+
+	// Add MAC filter if provided
+	if mac != "" {
+		req.Filter = &DeviceFilter{
+			MAC: cleanMAC(mac),
+		}
+	}
+
+	resp, err := c.makeRequest("POST", "/v2/rps/listDevices", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result DeviceSearchResponse
+	if err := decodeResponse(resp, &result, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetDeviceDetails retrieves detailed information about a device by its ID.
+func (c *Client) GetDeviceDetails(deviceID string) (*DeviceDetails, error) {
+	endpoint := fmt.Sprintf("/v2/rps/devices/%s", deviceID)
+	resp, err := c.makeRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var details DeviceDetails
+	if err := decodeResponse(resp, &details, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	return &details, nil
+}
+
+// GetDevicePINs retrieves PINs for multiple devices.
+// MAC addresses can be provided in any format (with or without separators).
+func (c *Client) GetDevicePINs(macs []string) ([]DevicePIN, error) {
+	// Clean MAC addresses
+	cleanedMACs := make([]string, len(macs))
+	for i, mac := range macs {
+		cleanedMACs[i] = cleanMAC(mac)
+	}
+
+	req := DevicePINRequest{
+		MACs: cleanedMACs,
+	}
+
+	resp, err := c.makeRequest("POST", "/v2/rps/listDevicePins", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var pins []DevicePIN
+	if err := decodeResponse(resp, &pins, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	return pins, nil
+}
+
+// GetSingleDevicePIN retrieves PIN for a single device.
+// This is a convenience method that calls GetDevicePINs with a single MAC address.
+func (c *Client) GetSingleDevicePIN(mac string) (string, error) {
+	pins, err := c.GetDevicePINs([]string{mac})
+	if err != nil {
+		return "", err
+	}
+
+	if len(pins) == 0 {
+		// PIN is optional; surface empty value without failing the call.
+		return "", nil
+	}
+
+	return pins[0].PIN, nil
+}
+
+// AddDevice adds a new device to the YMCS system.
+// Both MAC address and serial number (SN) are required.
+func (c *Client) AddDevice(req AddDeviceRequest) (*AddDeviceResponse, error) {
+	// Clean MAC address
+	req.MAC = cleanMAC(req.MAC)
+
+	resp, err := c.makeRequest("POST", "/v2/rps/devices", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result AddDeviceResponse
+	if err := decodeResponse(resp, &result, http.StatusCreated); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// AddDevicesByMac adds one or more devices without serial numbers (batch operation).
+// Maximum of 100 devices can be added in a single request.
+func (c *Client) AddDevicesByMac(devices []AddDeviceByMacRequest) (*AddDevicesByMacResponse, error) {
+	// Clean MAC addresses
+	for i := range devices {
+		devices[i].MAC = cleanMAC(devices[i].MAC)
+	}
+
+	resp, err := c.makeRequest("POST", "/v2/rps/addDevicesByMac", devices)
+	if err != nil {
+		return nil, err
+	}
+
+	var result AddDevicesByMacResponse
+	if err := decodeResponse(resp, &result, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// AddDeviceByMacSingle is a convenience method to add a single device by MAC without SN.
+func (c *Client) AddDeviceByMacSingle(mac string, uniqueServerURL *string) (*AddDevicesByMacResponse, error) {
+	req := AddDeviceByMacRequest{
+		MAC:             mac,
+		UniqueServerURL: uniqueServerURL,
+	}
+	return c.AddDevicesByMac([]AddDeviceByMacRequest{req})
+}
+
+// DeleteDevices deletes one or more devices from the YMCS system.
+// deviceIdType must be either "mac" or "id".
+func (c *Client) DeleteDevices(deviceIdType string, deviceIds []string) (*DeleteDevicesResponse, error) {
+	// Clean device IDs if using MAC addresses
+	if deviceIdType == "mac" {
+		cleanedIds := make([]string, len(deviceIds))
+		for i, id := range deviceIds {
+			cleanedIds[i] = cleanMAC(id)
+		}
+		deviceIds = cleanedIds
+	}
+
+	req := DeleteDevicesRequest{
+		DeviceIdType: deviceIdType,
+		DeviceIds:    deviceIds,
+	}
+
+	resp, err := c.makeRequest("POST", "/v2/rps/delDevices", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result DeleteDevicesResponse
+	if err := decodeResponse(resp, &result, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// DeleteDeviceByMAC is a convenience method to delete a single device by MAC address.
+func (c *Client) DeleteDeviceByMAC(mac string) (*DeleteDevicesResponse, error) {
+	return c.DeleteDevices("mac", []string{mac})
+}
+
+// DeleteDeviceByID is a convenience method to delete a single device by ID.
+func (c *Client) DeleteDeviceByID(deviceID string) (*DeleteDevicesResponse, error) {
+	return c.DeleteDevices("id", []string{deviceID})
+}

--- a/libs/ymcs/errors.go
+++ b/libs/ymcs/errors.go
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+package ymcs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// APIErrorDetail represents a single validation error returned by YMCS.
+type APIErrorDetail struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+// APIError models the standard YMCS error response payload and keeps HTTP context.
+type APIError struct {
+	HTTPStatus      int              `json:"-"`
+	Code            string           `json:"code"`
+	OAuthError      string           `json:"error"`
+	RequestID       string           `json:"requestId"`
+	Message         string           `json:"message"`
+	Details         []APIErrorDetail `json:"details"`
+	RawBody         string           `json:"-"`
+	FriendlyMessage string           `json:"-"`
+}
+
+// Error implements the error interface and exposes a compact summary.
+func (e APIError) Error() string {
+	parts := []string{}
+
+	if e.Code != "" {
+		parts = append(parts, fmt.Sprintf("code=%s", e.Code))
+	}
+	if e.OAuthError != "" {
+		parts = append(parts, fmt.Sprintf("oauth=%s", e.OAuthError))
+	}
+	if e.RequestID != "" {
+		parts = append(parts, fmt.Sprintf("requestId=%s", e.RequestID))
+	}
+
+	// Prefer the descriptive message if present.
+	msg := e.Message
+	if msg == "" {
+		msg = e.FriendlyMessage
+	}
+	if msg != "" {
+		parts = append(parts, fmt.Sprintf("message=%s", msg))
+	}
+
+	if e.FriendlyMessage != "" && e.FriendlyMessage != msg {
+		parts = append(parts, fmt.Sprintf("hint=%s", e.FriendlyMessage))
+	}
+
+	if len(parts) == 0 {
+		return fmt.Sprintf("ymcs error (status %d)", e.HTTPStatus)
+	}
+
+	return fmt.Sprintf("ymcs error (status %d): %s", e.HTTPStatus, strings.Join(parts, ", "))
+}
+
+// knownErrorCodes captures the main YMCS error codes documented in the API guide.
+var knownErrorCodes = map[string]string{
+	"70011":  "Invalid grant_type", // OAuth example
+	"800001": "Invalid MAC",
+	"800002": "Invalid SN",
+	"800003": "Resource already exists",
+	"800004": "Device already managed by another organization",
+	"800005": "Device type is invalid",
+	"800006": "Batch size exceeds limit",
+	"800007": "Invalid parameters",
+	"800008": "Data exceeds limit",
+	"800130": "Account already exists",
+	"800200": "Device type is invalid",
+	"900200": "Operation successful", // Included for completeness
+	"900400": "Request parameters are incorrect or missing",
+	"900401": "Not logged in or session expired",
+	"900403": "Request forbidden",
+	"900404": "Resource not found",
+	"900408": "Request timed out",
+	"900409": "Request conflict",
+	"900412": "Concurrent editing error",
+	"900429": "Too many requests (rate limited)",
+	"900440": "Session expired",
+	"900500": "Server busy, try again later",
+	"900501": "Operation not supported",
+	"900502": "Bad gateway",
+	"900503": "Service unavailable",
+	"900504": "Gateway timeout",
+	"900511": "Internal server error",
+	"900599": "Unknown server error",
+}
+
+// parseAPIError tries to decode the YMCS error payload, enriching it with friendly messages.
+// When the payload cannot be decoded, it falls back to a generic error that still carries the status code.
+func parseAPIError(status int, body []byte) error {
+	var apiErr APIError
+	if err := json.Unmarshal(body, &apiErr); err != nil {
+		// Fall back to a generic error with the raw payload to preserve context.
+		return fmt.Errorf("ymcs request failed with status %d: %s", status, strings.TrimSpace(string(body)))
+	}
+
+	apiErr.HTTPStatus = status
+	apiErr.RawBody = string(body)
+	apiErr.FriendlyMessage = knownErrorCodes[apiErr.Code]
+
+	// Fill missing message fields with whatever context we have.
+	if apiErr.Message == "" {
+		apiErr.Message = apiErr.FriendlyMessage
+	}
+	if apiErr.Message == "" && apiErr.OAuthError != "" {
+		apiErr.Message = apiErr.OAuthError
+	}
+
+	return apiErr
+}
+
+// statusAllowed reports whether the HTTP status code is one of the expected values.
+func statusAllowed(status int, allowed []int) bool {
+	for _, s := range allowed {
+		if status == s {
+			return true
+		}
+	}
+	return false
+}
+
+// decodeResponse validates the status code, decodes the body into the provided destination and returns
+// a structured APIError when the response contains a YMCS error payload.
+func decodeResponse(resp *http.Response, dst interface{}, allowedStatuses ...int) error {
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if !statusAllowed(resp.StatusCode, allowedStatuses) {
+		return parseAPIError(resp.StatusCode, body)
+	}
+
+	if dst == nil || len(body) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, dst); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return nil
+}

--- a/libs/ymcs/types.go
+++ b/libs/ymcs/types.go
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+// Package ymcs provides a client for the Yealink YMCS API with OAuth 2.0 authentication
+package ymcs
+
+// TokenResponse represents the OAuth 2.0 token response
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+// Device represents a device in the YMCS system
+type Device struct {
+	ID              string  `json:"id"`
+	MAC             string  `json:"mac"`
+	SN              *string `json:"sn"`
+	ServerID        *string `json:"serverId"`
+	ServerName      *string `json:"serverName"`
+	ServerURL       *string `json:"serverUrl"`
+	UniqueServerURL *string `json:"uniqueServerUrl"`
+	IPAddress       *string `json:"ipAddress"`
+	Remark          *string `json:"remark"`
+	DateRegistered  *int64  `json:"dateRegistered"`
+	LastConnected   *int64  `json:"lastConnected"`
+}
+
+// DeviceDetails represents detailed device information
+type DeviceDetails struct {
+	Device
+	AuthName *string `json:"authName"`
+}
+
+// DeviceSearchRequest represents the request body for device search
+type DeviceSearchRequest struct {
+	Skip      int           `json:"skip"`
+	Limit     int           `json:"limit"`
+	AutoCount bool          `json:"autoCount"`
+	Filter    *DeviceFilter `json:"filter,omitempty"`
+}
+
+// DeviceFilter represents search filters
+type DeviceFilter struct {
+	MAC string `json:"mac,omitempty"`
+}
+
+// DeviceSearchResponse represents the response from device search
+type DeviceSearchResponse struct {
+	Skip  int      `json:"skip"`
+	Limit int      `json:"limit"`
+	Total int      `json:"total"`
+	Data  []Device `json:"data"`
+}
+
+// DevicePIN represents a device PIN
+type DevicePIN struct {
+	MAC string `json:"mac"`
+	PIN string `json:"pin"`
+}
+
+// DevicePINRequest represents the request for device PINs
+type DevicePINRequest struct {
+	MACs []string `json:"macs"`
+}
+
+// AddDeviceRequest represents the request body for adding a device
+type AddDeviceRequest struct {
+	MAC             string  `json:"mac"`
+	SN              string  `json:"sn"`
+	ServerID        *string `json:"serverId,omitempty"`
+	UniqueServerURL *string `json:"uniqueServerUrl,omitempty"`
+	AuthName        *string `json:"authName,omitempty"`
+	Password        *string `json:"password,omitempty"`
+	Remark          *string `json:"remark,omitempty"`
+}
+
+// AddDeviceResponse represents the response from adding a device
+type AddDeviceResponse struct {
+	ID              string  `json:"id"`
+	MAC             string  `json:"mac"`
+	SN              string  `json:"sn"`
+	ServerID        *string `json:"serverId,omitempty"`
+	UniqueServerURL *string `json:"uniqueServerUrl,omitempty"`
+	AuthName        *string `json:"authName,omitempty"`
+	Remark          *string `json:"remark,omitempty"`
+}
+
+// AddDeviceByMacRequest represents a single device in batch add by MAC (no SN required)
+type AddDeviceByMacRequest struct {
+	MAC             string  `json:"mac"`
+	ServerID        *string `json:"serverId,omitempty"`
+	UniqueServerURL *string `json:"uniqueServerUrl,omitempty"`
+	AuthName        *string `json:"authName,omitempty"`
+	Password        *string `json:"password,omitempty"`
+	Remark          *string `json:"remark,omitempty"`
+}
+
+// AddError represents an error when adding a device
+type AddError struct {
+	MAC       string `json:"mac"`
+	SN        string `json:"sn"`
+	ErrorInfo string `json:"errorInfo"`
+}
+
+// AddDevicesByMacResponse represents the response from batch adding devices by MAC
+type AddDevicesByMacResponse struct {
+	Total        int        `json:"total"`
+	SuccessCount int        `json:"successCount"`
+	FailureCount int        `json:"failureCount"`
+	Errors       []AddError `json:"errors"`
+}
+
+// DeleteDevicesRequest represents the request body for deleting devices
+type DeleteDevicesRequest struct {
+	DeviceIdType string   `json:"deviceIdType"` // "mac" or "id"
+	DeviceIds    []string `json:"deviceIds"`    // List of device IDs or MACs
+}
+
+// OpError represents an error for a specific field
+type OpError struct {
+	Field string `json:"field"`
+	Msg   string `json:"msg"`
+}
+
+// DeleteDevicesResponse represents the response from deleting devices
+type DeleteDevicesResponse struct {
+	Total        int       `json:"total"`
+	SuccessCount int       `json:"successCount"`
+	FailureCount int       `json:"failureCount"`
+	Errors       []OpError `json:"errors"`
+}

--- a/methods/providerDispatch.go
+++ b/methods/providerDispatch.go
@@ -126,6 +126,40 @@ func ProviderDispatch(c *gin.Context) {
 			Override:   "1",
 		}
 
+	case (provider == "ymcs") && !configuration.Config.Providers.Ymcs.Disable:
+		mac, url, err := parseParams(c)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		redirectUrl, _ := net_url.QueryUnescape(url)
+
+		deviceYMCS := providers.YmcsDevice{
+			Mac: mac.A0 + "-" + mac.A1 + "-" + mac.A2 + "-" + mac.A3 + "-" + mac.A4 + "-" + mac.A5,
+			Url: redirectUrl,
+		}
+
+		if err := deviceYMCS.Register(); err != nil {
+			if errors.Unwrap(err) != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(),
+					"message": errors.Unwrap(err).Error()})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
+			return
+		}
+
+		pin, err := deviceYMCS.GetPIN()
+		if err != nil || pin == "" {
+			// PIN is optional: succeed even if the provider does not return it.
+			c.JSON(http.StatusOK, gin.H{"device_pin": nil})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"device_pin": pin})
+		return
+
 	default:
 		c.JSON(http.StatusNotFound, gin.H{"error": "provider_not_supported"})
 		return

--- a/methods/providerDispatch.go
+++ b/methods/providerDispatch.go
@@ -135,30 +135,10 @@ func ProviderDispatch(c *gin.Context) {
 
 		redirectUrl, _ := net_url.QueryUnescape(url)
 
-		deviceYMCS := providers.YmcsDevice{
+		device = providers.YmcsDevice{
 			Mac: mac.A0 + "-" + mac.A1 + "-" + mac.A2 + "-" + mac.A3 + "-" + mac.A4 + "-" + mac.A5,
 			Url: redirectUrl,
 		}
-
-		if err := deviceYMCS.Register(); err != nil {
-			if errors.Unwrap(err) != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(),
-					"message": errors.Unwrap(err).Error()})
-			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			}
-			return
-		}
-
-		pin, err := deviceYMCS.GetPIN()
-		if err != nil || pin == "" {
-			// PIN is optional: succeed even if the provider does not return it.
-			c.JSON(http.StatusOK, gin.H{"device_pin": nil})
-			return
-		}
-
-		c.JSON(http.StatusOK, gin.H{"device_pin": pin})
-		return
 
 	default:
 		c.JSON(http.StatusNotFound, gin.H{"error": "provider_not_supported"})
@@ -173,6 +153,18 @@ func ProviderDispatch(c *gin.Context) {
 		} else {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}
+		return
+	}
+
+	// Handle YMCS-specific PIN retrieval
+	if ymcsDevice, ok := device.(providers.YmcsDevice); ok {
+		pin, err := ymcsDevice.GetPIN()
+		if err != nil || pin == "" {
+			// PIN is optional: succeed even if the provider does not return it.
+			c.JSON(http.StatusOK, gin.H{"device_pin": nil})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"device_pin": pin})
 		return
 	}
 

--- a/providers/ymcs.go
+++ b/providers/ymcs.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+/*
+ * Yealink Management Cloud Service provider
+ */
+package providers
+
+import (
+	"errors"
+
+	"github.com/nethesis/falconieri/configuration"
+	"github.com/nethesis/falconieri/libs/ymcs"
+	"github.com/nethesis/falconieri/models"
+	"github.com/nethesis/falconieri/utils"
+)
+
+type YmcsDevice struct {
+	Mac string
+	Url string
+}
+
+func (s YmcsDevice) Register() error {
+	client := ymcs.NewClient(
+		configuration.Config.Providers.Ymcs.BaseURL,
+		configuration.Config.Providers.Ymcs.ClientID,
+		configuration.Config.Providers.Ymcs.ClientSecret,
+	)
+
+	// Delete device first (if it exists) to ensure clean registration
+	_, err := client.DeleteDeviceByMAC(s.Mac)
+	if err != nil {
+		// Ignore deletion errors (device may not exist)
+		// Log but continue with registration
+	}
+
+	resp, err := client.AddDeviceByMacSingle(s.Mac, &s.Url)
+	if err != nil {
+		return models.ProviderError{
+			Message:      "provider_remote_call_failed",
+			WrappedError: err,
+		}
+	}
+
+	if resp == nil {
+		return errors.New("unknown_response_from_provider")
+	}
+
+	if resp.FailureCount > 0 && len(resp.Errors) > 0 {
+		return utils.ParseProviderError(resp.Errors[0].ErrorInfo)
+	}
+
+	if resp.SuccessCount == 0 {
+		return errors.New("provider_remote_call_failed")
+	}
+
+	return nil
+}
+
+func (s YmcsDevice) GetPIN() (string, error) {
+	client := ymcs.NewClient(
+		configuration.Config.Providers.Ymcs.BaseURL,
+		configuration.Config.Providers.Ymcs.ClientID,
+		configuration.Config.Providers.Ymcs.ClientSecret,
+	)
+
+	return client.GetSingleDevicePIN(s.Mac)
+}

--- a/providers/ymcs.go
+++ b/providers/ymcs.go
@@ -27,6 +27,7 @@ package providers
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/nethesis/falconieri/configuration"
 	"github.com/nethesis/falconieri/libs/ymcs"
@@ -34,17 +35,33 @@ import (
 	"github.com/nethesis/falconieri/utils"
 )
 
+var (
+	ymcsClient     *ymcs.Client
+	ymcsClientOnce sync.Once
+)
+
+// getYmcsClient returns a singleton YMCS client instance.
+// This allows token caching to work effectively across multiple requests.
+// The client is created using configuration loaded at startup.
+// Errors during API calls are handled by the client's methods.
+func getYmcsClient() *ymcs.Client {
+	ymcsClientOnce.Do(func() {
+		ymcsClient = ymcs.NewClient(
+			configuration.Config.Providers.Ymcs.BaseURL,
+			configuration.Config.Providers.Ymcs.ClientID,
+			configuration.Config.Providers.Ymcs.ClientSecret,
+		)
+	})
+	return ymcsClient
+}
+
 type YmcsDevice struct {
 	Mac string
 	Url string
 }
 
 func (s YmcsDevice) Register() error {
-	client := ymcs.NewClient(
-		configuration.Config.Providers.Ymcs.BaseURL,
-		configuration.Config.Providers.Ymcs.ClientID,
-		configuration.Config.Providers.Ymcs.ClientSecret,
-	)
+	client := getYmcsClient()
 
 	// Delete device first (if it exists) to ensure clean registration
 	_, err := client.DeleteDeviceByMAC(s.Mac)
@@ -77,11 +94,7 @@ func (s YmcsDevice) Register() error {
 }
 
 func (s YmcsDevice) GetPIN() (string, error) {
-	client := ymcs.NewClient(
-		configuration.Config.Providers.Ymcs.BaseURL,
-		configuration.Config.Providers.Ymcs.ClientID,
-		configuration.Config.Providers.Ymcs.ClientSecret,
-	)
+	client := getYmcsClient()
 
 	return client.GetSingleDevicePIN(s.Mac)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -76,7 +76,10 @@ func ParseProviderError(message string) error {
 		message == "Error: device_had_existed",                         //fanvil
 		strings.HasPrefix(message, "mac_already_in_use:"),              //gigaset
 		regexp.MustCompile(`^Error:[a-z0-9]{10}`).MatchString(message), //yealink
-		message == "800004": //ymcs
+		message == "800004", //ymcs
+		message == "800003", //ymcs: Resource already exists
+		strings.Contains(strings.ToLower(message), "device already managed"),
+		strings.Contains(strings.ToLower(message), "resource already exists"):
 
 		return errors.New("device_owned_by_other_user")
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -65,15 +65,18 @@ func ParseProviderError(message string) error {
 		return errors.New("malformed_url")
 
 	case message == "Error:malformed_mac", //snom
-		message == "Error: mac_format_error",         //fanvil
-		strings.HasPrefix(message, "mac_not_exist:"): //gigaset
+		message == "Error: mac_format_error",                             //fanvil
+		strings.HasPrefix(message, "mac_not_exist:"),                     //gigaset
+		strings.Contains(strings.ToLower(message), "device.mac.invalid"), // ymcs example errorInfo
+		message == "800001":                                              // ymcs error code: invalid MAC
 
 		return errors.New("not_valid_mac_address")
 
 	case message == "Error:owned_by_other_user", //snom
 		message == "Error: device_had_existed",                         //fanvil
 		strings.HasPrefix(message, "mac_already_in_use:"),              //gigaset
-		regexp.MustCompile(`^Error:[a-z0-9]{10}`).MatchString(message): //yealink
+		regexp.MustCompile(`^Error:[a-z0-9]{10}`).MatchString(message), //yealink
+		message == "800004": //ymcs
 
 		return errors.New("device_owned_by_other_user")
 


### PR DESCRIPTION
This PR integrates the Yealink Management Cloud Service (YMCS) provider into
the application. It introduces a dedicated client library for interacting with
the YMCS API and wire up the provider logic for device registration.

**Key Changes:**

*   **New Client Library (ymcs):** Implemented a robust Go client handling
    OAuth2 authentication, device management, and strictly typed API responses.
*   **Provider Integration:** Added the YMCS provider logic, including
    configuration parsing and dispatch handlers for device registration and PIN
    retrieval.
*   **Error Handling:** Enhanced error definitions to specifically handle YMCS
    API error formats, such as invalid MAC addresses and ownership conflicts.

https://github.com/NethServer/dev/issues/7765
