### PR TITLE
feat: add GRAPE provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Supported providers:
 * Fanvil (a link to its public documentation was not found)
 * [Yealink (legacy provider)](https://support-cdn.yealink.com/attachment/upload/attachment/2019-1-8/5/b6a08cc4-0d6c-4def-b2f4-224b9653c051/Yealink+XML+API+for+RPS-V1.6-ENG.pdf)
 * [YMCS (Yealink Management Cloud Service V4X)](https://support.yealink.com/document-detail/c0966bbacb51405397c55290c2925f65) To use the YMCS provider, you need to ask Yealink to enable `/v2/rps/addDevicesByMac` endpoint for your account.
+* [Grape (Gigaset Redirect and Provisioning Environment)](https://teamwork.gigaset.com/gigawiki/pages/viewpage.action?pageId=1535868981)
 
 ## APIs
 
@@ -117,12 +118,13 @@ Gigaset specific:
 
 * `disable_crc` If set to `true` Falconieri don't send the mac address's CRC code, default `false`
 
-YMCS specific:
+YMCS and GRAPE specific:
 
-* `base_url` YMCS API base URL, for example `https://eu-api.ymcs.yealink.com`
-* `client_id` OAuth client ID issued by Yealink
-* `client_secret` OAuth client secret issued by Yealink
-
+* `base_url` API base URL, for example:
+  * `https://eu-api.ymcs.yealink.com` for YMCS provider
+  * `https://api.grape.gigaset.net/api/v1/` for Grape provider
+* `client_id` Client ID
+* `client_secret` Client secret/key
 
 Example:
 
@@ -140,7 +142,14 @@ Example:
        "client_id": "your-client-id",
        "client_secret": "your-client-secret",
        "disable": false
+     },
+     "grape": {
+       "base_url": "https://api.grape.gigaset.net/api/v1/",
+       "client_id": "your-client-id",
+       "client_secret": "your-client-secret",
+       "disable": false
      }
+  }
 }
 ```
 
@@ -171,6 +180,11 @@ Example:
 * `YMCS_CLIENT_ID` OAuth client ID issued by Yealink
 * `YMCS_CLIENT_SECRET` OAuth client secret issued by Yealink
 * `YMCS_DISABLE` Enable/Disable the YMCS provider, default `false`
+
+* `GRAPE_BASE_URL` Grape API base URL, for example `https://api.grape.gigaset.net/api/v1/`
+* `GRAPE_CLIENT_ID` Hawk id issued by Gigaset for HMAC authentication
+* `GRAPE_CLIENT_SECRET` Hawk key issued by Gigaset for HMAC authentication
+* `GRAPE_DISABLE` Enable/Disable the Grape provider, default `false`
 
 ## Other projects
 

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 )
 
-type ProviderConf struct {
+type LegacyProviderConf struct {
 	Password string `json:"password"`
 	User     string `json:"user"`
 	RpcUrl   string `json:"rpc_url"`
@@ -37,11 +37,11 @@ type ProviderConf struct {
 }
 
 type GigasetConf struct {
-	ProviderConf
+	LegacyProviderConf
 	DisableCrc bool `json:"disable_crc"`
 }
 
-type YmcsConf struct {
+type ProviderConf struct {
 	Disable      bool   `json:"disable"`
 	BaseURL      string `json:"base_url"`
 	ClientID     string `json:"client_id"`
@@ -50,12 +50,12 @@ type YmcsConf struct {
 
 type Configuration struct {
 	Providers struct {
-		Snom    ProviderConf `json:"snom"`
-		Gigaset GigasetConf  `json:"gigaset"`
-		Fanvil  ProviderConf `json:"fanvil"`
-		Yealink ProviderConf `json:"yealink"`
-		Ymcs    YmcsConf     `json:"ymcs"`
-	} `json: "providers"`
+		Snom    LegacyProviderConf `json:"snom"`
+		Gigaset GigasetConf        `json:"gigaset"`
+		Fanvil  LegacyProviderConf `json:"fanvil"`
+		Yealink LegacyProviderConf `json:"yealink"`
+		Ymcs    ProviderConf       `json:"ymcs"`
+	} `json:"providers"`
 }
 
 var Config = Configuration{}

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -55,6 +55,7 @@ type Configuration struct {
 		Fanvil  LegacyProviderConf `json:"fanvil"`
 		Yealink LegacyProviderConf `json:"yealink"`
 		Ymcs    ProviderConf       `json:"ymcs"`
+		Grape   ProviderConf       `json:"grape"`
 	} `json:"providers"`
 }
 
@@ -219,5 +220,33 @@ func Init(ConfigFilePtr *string) {
 			Config.Providers.Ymcs.BaseURL == "") {
 
 		Config.Providers.Ymcs.Disable = true
+	}
+	// GRAPE provider configuration
+	if os.Getenv("GRAPE_CLIENT_ID") != "" {
+		Config.Providers.Grape.ClientID = os.Getenv("GRAPE_CLIENT_ID")
+	}
+
+	if os.Getenv("GRAPE_CLIENT_SECRET") != "" {
+		Config.Providers.Grape.ClientSecret = os.Getenv("GRAPE_CLIENT_SECRET")
+	}
+
+	if os.Getenv("GRAPE_BASE_URL") != "" {
+		Config.Providers.Grape.BaseURL = os.Getenv("GRAPE_BASE_URL")
+	}
+
+	if os.Getenv("GRAPE_DISABLE") != "" {
+
+		disable, err := strconv.ParseBool(os.Getenv("GRAPE_DISABLE"))
+		if err == nil {
+			Config.Providers.Grape.Disable = disable
+		}
+	}
+
+	if !Config.Providers.Grape.Disable &&
+		(Config.Providers.Grape.ClientID == "" ||
+			Config.Providers.Grape.ClientSecret == "" ||
+			Config.Providers.Grape.BaseURL == "") {
+
+		Config.Providers.Grape.Disable = true
 	}
 }

--- a/deploy/ansible/roles/falconieri/defaults/main.yml
+++ b/deploy/ansible/roles/falconieri/defaults/main.yml
@@ -27,3 +27,8 @@ ymcs_base_url: https://eu-api.ymcs.yealink.com
 ymcs_client_id: client
 ymcs_client_secret: secret
 ymcs_disable: "false"
+
+grape_base_url: https://api.grape.gigaset.net/api/v1/
+grape_client_id: client
+grape_client_secret: secret
+grape_disable: "false"

--- a/deploy/ansible/roles/falconieri/templates/conf.json.tpl
+++ b/deploy/ansible/roles/falconieri/templates/conf.json.tpl
@@ -30,6 +30,12 @@
       "client_id": "{{ ymcs_client_id }}",
       "client_secret": "{{ ymcs_client_secret }}",
       "disable": {{ ymcs_disable }}
+    },
+    "grape": {
+      "base_url": "{{ grape_base_url }}",
+      "client_id": "{{ grape_client_id }}",
+      "client_secret": "{{ grape_client_secret }}",
+      "disable": {{ grape_disable }}
     }
   }
 }

--- a/libs/grape/API_MANUAL.md
+++ b/libs/grape/API_MANUAL.md
@@ -1,0 +1,687 @@
+# Grape Provisioning API Client Library - Technical Manual
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Installation](#installation)
+3. [Package Overview](#package-overview)
+4. [Client Initialization](#client-initialization)
+5. [Authentication](#authentication)
+6. [Device Management](#device-management)
+7. [Data Types](#data-types)
+8. [Error Handling](#error-handling)
+9. [Code Examples](#code-examples)
+10. [Advanced Usage](#advanced-usage)
+
+---
+
+## Introduction
+
+The Grape Provisioning API Client Library provides a comprehensive Go interface for interacting with the Grape provisioning service API. This library implements Hawk HTTP authentication (HMAC-based) and offers device management operations with automatic API navigation and caching.
+
+### Key Features
+
+- Full Hawk HTTP authentication implementation
+- Automatic API navigation (HATEOAS-based discovery)
+- Caching of API endpoints for improved performance
+- Device provisioning and registration
+- MAC address normalization (supports multiple formats)
+- Thread-safe implementation for concurrent use
+- Comprehensive type definitions
+- Built-in debug capabilities
+
+### API Endpoints Reference
+
+The library abstracts the following Grape API endpoints:
+
+| Operation | Endpoint | HTTP Method | Library Method |
+|-----------|----------|-------------|----------------|
+| Get Settings | `/settings/` | GET | Internal: `getProvisioningServerID()` |
+| Get Token Info | `/tokens/{clientID}` | GET | Internal: `getEndpointsURL()` |
+| Get Company Info | `{company_link}` | GET | Internal: `getEndpointsURL()` |
+| Register Device | `{endpoints_url}{mac}` | PUT | `RegisterDevice()` |
+
+### Package Information
+
+- **Package Name**: `grape`
+- **Import Path**: `github.com/nethesis/falconieri/libs/grape`
+- **Go Version**: 1.17 or higher
+- **Authentication**: Hawk (HMAC-based)
+- **No External Dependencies**: Uses only Go standard library
+
+---
+
+## Installation
+
+### Using Go Modules
+
+Add the library to your project:
+
+```bash
+go get github.com/nethesis/falconieri@latest
+```
+
+### Import Statement
+
+```go
+import "github.com/nethesis/falconieri/libs/grape"
+```
+
+---
+
+## Package Overview
+
+The library is organized into the following components:
+
+### Core Components
+
+- **Client**: Main client structure for API interactions with caching
+- **Authentication**: Hawk HTTP authentication implementation
+- **Device Operations**: Device registration and provisioning
+- **Types**: Data structures for requests and responses
+- **Error Handling**: Structured error parsing
+
+### File Structure
+
+```
+libs/grape/
+├── client.go        # Core client implementation and MAC normalization
+├── auth.go          # Hawk authentication (nonce, MAC, signatures)
+├── devices.go       # Device management operations
+├── errors.go        # Grape API error parsing and structured error type
+├── types.go         # Data type definitions
+└── API_MANUAL.md    # This documentation file
+```
+
+---
+
+## Client Initialization
+
+### Creating a New Client
+
+```go
+package main
+
+import "github.com/nethesis/falconieri/libs/grape"
+
+func main() {
+    client := grape.NewClient(
+        "https://api.grape.example.com/",  // Base URL
+        "your-client-id",                    // Client ID
+        "your-client-secret",                // Client Secret
+    )
+}
+```
+
+### Client Configuration
+
+The client is automatically configured with:
+- HTTP timeout: 30 seconds
+- Thread-safe API navigation caching
+- Automatic MAC address normalization
+
+### Debug Mode
+
+Enable debug mode to inspect HTTP requests and responses:
+
+```go
+client := grape.NewClient(baseURL, clientID, clientSecret)
+client.Debug = true
+
+// After API calls, inspect debug information:
+fmt.Printf("Last Request: %+v\n", client.LastRequest)
+fmt.Printf("Last Request Body: %s\n", client.LastRequestBody)
+fmt.Printf("Last Response: %+v\n", client.LastResponse)
+fmt.Printf("Last Response Body: %s\n", client.LastRespBody)
+```
+
+---
+
+## Authentication
+
+### Hawk HTTP Authentication
+
+The Grape API uses Hawk authentication, an HMAC-based HTTP authentication scheme. The library handles all authentication details automatically.
+
+#### Hawk Authentication Flow
+
+1. **Nonce Generation**: 16 bytes of cryptographically secure random data
+2. **Payload Hashing**: SHA256 hash of request body in Hawk format
+3. **MAC Calculation**: HMAC-SHA256 signature of normalized request
+4. **Authorization Header**: Constructed with id, timestamp, nonce, hash, and MAC
+
+#### Hawk Header Format
+
+```
+Hawk id="{clientID}", ts="{timestamp}", nonce="{nonce}", hash="{payloadHash}", mac="{mac}"
+```
+
+#### Authentication Components
+
+- **ID**: Client identifier
+- **Key**: Client secret for HMAC
+- **Timestamp**: Unix timestamp
+- **Nonce**: Cryptographically random value
+- **Hash**: SHA256 payload hash
+- **MAC**: HMAC-SHA256 signature
+
+### Automatic Authentication
+
+All API requests are automatically authenticated using Hawk. No manual token management is required.
+
+---
+
+## Device Management
+
+### Register Device
+
+Register a device with the Grape provisioning server.
+
+#### Method Signature
+
+```go
+func (c *Client) RegisterDevice(mac, provisioningURL string) error
+```
+
+#### Parameters
+
+- `mac`: MAC address in any format (e.g., `AA:BB:CC:DD:EE:FF`, `AA-BB-CC-DD-EE-FF`, `AABBCCDDEEFF`)
+- `provisioningURL`: The URL of the provisioning server
+
+#### Example
+
+```go
+client := grape.NewClient(baseURL, clientID, clientSecret)
+
+err := client.RegisterDevice("00:15:65:4F:A1:2B", "https://provision.example.com/config.xml")
+if err != nil {
+    log.Fatalf("Failed to register device: %v", err)
+}
+
+fmt.Println("Device registered successfully")
+```
+
+#### MAC Address Formats
+
+The library automatically normalizes MAC addresses. All these formats are accepted:
+
+- `AA:BB:CC:DD:EE:FF` (colon-separated)
+- `AA-BB-CC-DD-EE-FF` (dash-separated)
+- `AA.BB.CC.DD.EE.FF` (dot-separated)
+- `AABBCCDDEEFF` (no separators)
+- `aabbccddeeff` (lowercase)
+
+All formats are normalized to lowercase without separators: `aabbccddeeff`
+
+### API Navigation Caching
+
+The library automatically discovers and caches API endpoints:
+
+1. **ProvisioningServer UUID**: Retrieved once from `/settings/`
+2. **Endpoints URL**: Retrieved once through token and company links
+
+These values are cached per client instance for improved performance. Subsequent `RegisterDevice()` calls reuse cached values.
+
+---
+
+## Data Types
+
+### Setting
+
+Represents a configuration setting in the Grape API.
+
+```go
+type Setting struct {
+    UUID      string `json:"uuid"`
+    ParamName string `json:"param_name"`
+}
+```
+
+### TokenResponse
+
+Response from the token endpoint containing navigation links.
+
+```go
+type TokenResponse struct {
+    Links struct {
+        Company string `json:"company"`
+    } `json:"links"`
+}
+```
+
+### CompanyResponse
+
+Response from the company endpoint containing navigation links.
+
+```go
+type CompanyResponse struct {
+    Links struct {
+        Endpoints string `json:"endpoints"`
+    } `json:"links"`
+}
+```
+
+### DeviceData
+
+Data structure for registering a device.
+
+```go
+type DeviceData struct {
+    MAC                     string                            `json:"mac"`
+    AutoprovisioningEnabled bool                              `json:"autoprovisioning_enabled"`
+    SettingsManager         map[string]map[string]interface{} `json:"settings_manager"`
+}
+```
+
+---
+
+## Error Handling
+
+### APIError Type
+
+The library provides a structured error type for API errors.
+
+```go
+type APIError struct {
+    StatusCode int    // HTTP status code
+    Status     string // HTTP status message
+    Message    string // Parsed error message
+    Body       string // Raw response body
+}
+```
+
+### Error Method
+
+```go
+func (e APIError) Error() string
+```
+
+Returns a formatted error message: `Grape API error (HTTP {code}): {message}`
+
+### Checking for API Errors
+
+The GRAPE client returns `APIError` instances for HTTP 4xx/5xx responses. Use `errors.As()` to check for API errors:
+
+```go
+err := client.RegisterDevice(mac, url)
+if err != nil {
+    var apiErr grape.APIError
+    if errors.As(err, &apiErr) {
+        fmt.Printf("API Error: HTTP %d - %s\n", apiErr.StatusCode, apiErr.Message)
+        fmt.Printf("Raw Response: %s\n", apiErr.Body)
+    } else {
+        fmt.Printf("Other Error: %v\n", err)
+    }
+}
+```
+
+### Common Error Scenarios
+
+- **401 Unauthorized**: Invalid client credentials
+- **404 Not Found**: Device or endpoint not found
+- **400 Bad Request**: Invalid MAC address or parameters
+- **500 Internal Server Error**: Grape API server error
+
+---
+
+## Code Examples
+
+### Basic Device Registration
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/nethesis/falconieri/libs/grape"
+)
+
+func main() {
+    // Create client
+    client := grape.NewClient(
+        "https://api.grape.example.com/",
+        "my-client-id",
+        "my-client-secret",
+    )
+
+    // Register device
+    mac := "00:15:65:4F:A1:2B"
+    provURL := "https://provision.example.com/config.xml"
+
+    err := client.RegisterDevice(mac, provURL)
+    if err != nil {
+        log.Fatalf("Failed to register device: %v", err)
+    }
+
+    fmt.Println("Device registered successfully!")
+}
+```
+
+### Register Multiple Devices
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/nethesis/falconieri/libs/grape"
+)
+
+func main() {
+    client := grape.NewClient(baseURL, clientID, clientSecret)
+
+    devices := []struct {
+        MAC string
+        URL string
+    }{
+        {"00:15:65:4F:A1:2B", "https://provision.example.com/device1.xml"},
+        {"00:15:65:4F:A1:2C", "https://provision.example.com/device2.xml"},
+        {"00:15:65:4F:A1:2D", "https://provision.example.com/device3.xml"},
+    }
+
+    for _, dev := range devices {
+        err := client.RegisterDevice(dev.MAC, dev.URL)
+        if err != nil {
+            log.Printf("Failed to register %s: %v", dev.MAC, err)
+            continue
+        }
+        fmt.Printf("Registered %s successfully\n", dev.MAC)
+    }
+}
+```
+
+### Error Handling Example
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/nethesis/falconieri/libs/grape"
+)
+
+func registerDevice(client *grape.Client, mac, url string) error {
+    err := client.RegisterDevice(mac, url)
+    if err != nil {
+        // Check if it's an API error
+        if apiErr, ok := err.(grape.APIError); ok {
+            switch apiErr.StatusCode {
+            case 401:
+                return fmt.Errorf("authentication failed: check credentials")
+            case 404:
+                return fmt.Errorf("device or endpoint not found")
+            case 400:
+                return fmt.Errorf("invalid request: %s", apiErr.Message)
+            default:
+                return fmt.Errorf("API error %d: %s", apiErr.StatusCode, apiErr.Message)
+            }
+        }
+        return fmt.Errorf("network or other error: %w", err)
+    }
+    return nil
+}
+
+func main() {
+    client := grape.NewClient(baseURL, clientID, clientSecret)
+
+    err := registerDevice(client, "00:15:65:4F:A1:2B", "https://provision.example.com/config.xml")
+    if err != nil {
+        log.Fatalf("Registration failed: %v", err)
+    }
+
+    fmt.Println("Device registered!")
+}
+```
+
+### Debug Mode Example
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/nethesis/falconieri/libs/grape"
+)
+
+func main() {
+    client := grape.NewClient(baseURL, clientID, clientSecret)
+    client.Debug = true
+
+    err := client.RegisterDevice("00:15:65:4F:A1:2B", "https://provision.example.com/config.xml")
+
+    // Inspect the last request
+    fmt.Println("=== Last Request ===")
+    fmt.Printf("Method: %s\n", client.LastRequest.Method)
+    fmt.Printf("URL: %s\n", client.LastRequest.URL)
+    fmt.Printf("Headers: %+v\n", client.LastRequest.Header)
+    fmt.Printf("Body: %s\n", client.LastRequestBody)
+
+    // Inspect the last response
+    fmt.Println("\n=== Last Response ===")
+    fmt.Printf("Status: %d %s\n", client.LastResponse.StatusCode, client.LastResponse.Status)
+    fmt.Printf("Headers: %+v\n", client.LastResponse.Header)
+    fmt.Printf("Body: %s\n", client.LastRespBody)
+
+    if err != nil {
+        log.Fatalf("Error: %v", err)
+    }
+}
+```
+
+---
+
+## Advanced Usage
+
+### Singleton Pattern (Recommended)
+
+For applications making multiple API calls, use a singleton pattern to benefit from caching:
+
+```go
+package main
+
+import (
+    "sync"
+
+    "github.com/nethesis/falconieri/libs/grape"
+)
+
+var (
+    grapeClient     *grape.Client
+    grapeClientOnce sync.Once
+)
+
+func getGrapeClient() *grape.Client {
+    grapeClientOnce.Do(func() {
+        grapeClient = grape.NewClient(
+            "https://api.grape.example.com/",
+            "my-client-id",
+            "my-client-secret",
+        )
+    })
+    return grapeClient
+}
+
+func main() {
+    // All calls use the same client instance (with cached API navigation)
+    client := getGrapeClient()
+
+    client.RegisterDevice("00:15:65:4F:A1:2B", "https://provision.example.com/config1.xml")
+    client.RegisterDevice("00:15:65:4F:A1:2C", "https://provision.example.com/config2.xml")
+    // Subsequent calls reuse cached ProvisioningServer UUID and endpoints URL
+}
+```
+
+### Thread Safety
+
+The client is thread-safe for concurrent use:
+
+```go
+package main
+
+import (
+    "sync"
+
+    "github.com/nethesis/falconieri/libs/grape"
+)
+
+func main() {
+    client := grape.NewClient(baseURL, clientID, clientSecret)
+
+    var wg sync.WaitGroup
+    devices := []string{
+        "00:15:65:4F:A1:2B",
+        "00:15:65:4F:A1:2C",
+        "00:15:65:4F:A1:2D",
+    }
+
+    for _, mac := range devices {
+        wg.Add(1)
+        go func(m string) {
+            defer wg.Done()
+            err := client.RegisterDevice(m, "https://provision.example.com/config.xml")
+            if err != nil {
+                log.Printf("Failed to register %s: %v", m, err)
+            }
+        }(mac)
+    }
+
+    wg.Wait()
+}
+```
+
+### Custom HTTP Client
+
+To customize the HTTP client (e.g., for proxies or custom TLS):
+
+```go
+package main
+
+import (
+    "crypto/tls"
+    "net/http"
+    "time"
+
+    "github.com/nethesis/falconieri/libs/grape"
+)
+
+func main() {
+    client := grape.NewClient(baseURL, clientID, clientSecret)
+
+    // Customize HTTP client
+    client.HTTPClient = &http.Client{
+        Timeout: 60 * time.Second,
+        Transport: &http.Transport{
+            TLSClientConfig: &tls.Config{
+                InsecureSkipVerify: false,
+            },
+        },
+    }
+
+    // Use client normally
+    err := client.RegisterDevice("00:15:65:4F:A1:2B", "https://provision.example.com/config.xml")
+    // ...
+}
+```
+
+### Cache Reset
+
+If you need to reset cached API navigation (e.g., after configuration changes):
+
+```go
+// Create a new client instance to reset cache
+client = grape.NewClient(baseURL, newClientID, newClientSecret)
+```
+
+---
+
+## Best Practices
+
+### 1. Use Singleton Pattern
+
+Reuse the same client instance across your application to benefit from API navigation caching.
+
+### 2. Error Handling
+
+Always check for errors and handle API-specific error codes appropriately.
+
+### 3. MAC Address Flexibility
+
+Let the library handle MAC address normalization—accept any format from users.
+
+### 4. Debug Mode in Development
+
+Enable debug mode during development to troubleshoot API issues:
+
+```go
+client.Debug = true
+```
+
+Disable in production for performance.
+
+### 5. Timeouts
+
+The default 30-second timeout is suitable for most cases. Adjust if needed:
+
+```go
+client.HTTPClient.Timeout = 60 * time.Second
+```
+
+### 6. Thread Safety
+
+The client is thread-safe, but create only one instance per application for optimal caching.
+
+---
+
+## Troubleshooting
+
+### Authentication Failures (401)
+
+- Verify `ClientID` and `ClientSecret` are correct
+- Check that credentials have proper permissions
+- Enable debug mode to inspect the Hawk authentication header
+
+### Device Not Found (404)
+
+- Verify the device MAC address is correct
+- Ensure the device exists in the Grape system
+- Check API navigation endpoints are accessible
+
+### Invalid Request (400)
+
+- Verify MAC address format (library normalizes automatically)
+- Check provisioning URL is well-formed
+- Review error message for specific validation issues
+
+### Network Errors
+
+- Check network connectivity to Grape API
+- Verify base URL is correct and accessible
+- Ensure no firewall blocking HTTP/HTTPS traffic
+- Consider increasing timeout for slow networks
+
+---
+
+## Support
+
+For issues, questions, or contributions:
+
+- **Repository**: https://github.com/nethesis/falconieri
+- **Issues**: https://github.com/nethesis/falconieri/issues
+
+---
+
+## License
+
+Copyright (C) 2026 Nethesis S.r.l.
+
+This library is part of the Falconieri project and is licensed under the GNU Affero General Public License v3.0 or later.
+
+See LICENSE file for details.

--- a/libs/grape/auth.go
+++ b/libs/grape/auth.go
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+package grape
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// HawkCredentials represents the Hawk authentication credentials
+type HawkCredentials struct {
+	ID  string
+	Key string
+}
+
+// generateNonce creates a cryptographically secure nonce
+func generateNonce() string {
+	// Generate 16 bytes (128 bits) of random data
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		// Fallback to nanosecond timestamp if crypto/rand fails
+		// This is extremely rare but provides a safety net
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	// Return base64-encoded random bytes (URL-safe encoding)
+	return base64.URLEncoding.EncodeToString(bytes)
+}
+
+// calculatePayloadHash computes SHA256 hash of the payload
+func calculatePayloadHash(payload []byte, contentType string) string {
+	// Hawk payload hash format: hawk.1.payload\n{content-type}\n{payload}\n
+	hashContent := fmt.Sprintf("hawk.1.payload\n%s\n", contentType)
+	if payload != nil {
+		hashContent += string(payload)
+	}
+	hashContent += "\n"
+
+	hash := sha256.Sum256([]byte(hashContent))
+	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+// calculateMAC computes the HMAC-SHA256 for Hawk authentication
+func calculateMAC(creds *HawkCredentials, method, uri, host, port, timestamp, nonce, payloadHash string) string {
+	// Construct the normalized request string according to Hawk specification
+	normalized := fmt.Sprintf("hawk.1.header\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n\n",
+		timestamp,
+		nonce,
+		strings.ToUpper(method),
+		uri,
+		host,
+		port,
+		payloadHash)
+
+	// Calculate HMAC-SHA256
+	h := hmac.New(sha256.New, []byte(creds.Key))
+	h.Write([]byte(normalized))
+	mac := h.Sum(nil)
+
+	return base64.StdEncoding.EncodeToString(mac)
+}
+
+// createHawkAuthHeader creates the Hawk Authorization header
+func createHawkAuthHeader(creds *HawkCredentials, method, rawURL string, payload []byte, contentType string) (string, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %v", err)
+	}
+
+	// Extract components needed for Hawk
+	host := parsedURL.Hostname()
+	port := parsedURL.Port()
+	if port == "" {
+		if parsedURL.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+
+	// Generate timestamp and nonce
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	nonce := generateNonce()
+
+	// Calculate payload hash
+	var payloadHash string
+	if payload != nil && len(payload) > 0 {
+		payloadHash = calculatePayloadHash(payload, contentType)
+	} else {
+		payloadHash = calculatePayloadHash(nil, "")
+	}
+
+	// Calculate MAC
+	uri := parsedURL.RequestURI()
+	mac := calculateMAC(creds, method, uri, host, port, timestamp, nonce, payloadHash)
+
+	// Construct the Authorization header
+	authHeader := fmt.Sprintf(`Hawk id="%s", ts="%s", nonce="%s", hash="%s", mac="%s"`,
+		creds.ID, timestamp, nonce, payloadHash, mac)
+
+	return authHeader, nil
+}
+
+// makeHawkRequest performs an HTTP request with Hawk authentication
+func (c *Client) makeHawkRequest(method, url string, body []byte) ([]byte, error) {
+	var req *http.Request
+	var err error
+	var contentType string
+
+	if body != nil {
+		req, err = http.NewRequest(method, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		contentType = "application/json"
+		req.Header.Set("Content-Type", contentType)
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		contentType = ""
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	// Create Hawk credentials
+	creds := &HawkCredentials{
+		ID:  c.ClientID,
+		Key: c.ClientSecret,
+	}
+
+	// Add Hawk authentication header
+	authHeader, err := createHawkAuthHeader(creds, method, url, body, contentType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Hawk auth header: %v", err)
+	}
+
+	req.Header.Set("Authorization", authHeader)
+
+	// Store request for debugging
+	if c.Debug {
+		c.debugMu.Lock()
+		c.LastRequest = req
+		c.LastRequestBody = string(body)
+		c.debugMu.Unlock()
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Store response for debugging
+	if c.Debug {
+		c.debugMu.Lock()
+		c.LastResponse = resp
+		c.LastRespBody = string(bodyBytes)
+		c.debugMu.Unlock()
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, parseErrorResponse(resp.StatusCode, resp.Status, bodyBytes)
+	}
+
+	return bodyBytes, nil
+}

--- a/libs/grape/client.go
+++ b/libs/grape/client.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+package grape
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Client represents a Grape API client
+type Client struct {
+	BaseURL      string
+	ClientID     string
+	ClientSecret string
+	HTTPClient   *http.Client
+	Debug        bool
+
+	// Cached API navigation data (thread-safe using sync.Once)
+	provisioningServerIDOnce sync.Once
+	provisioningServerID     string
+	provisioningServerIDErr  error
+
+	endpointsURLOnce sync.Once
+	endpointsURL     string
+	endpointsURLErr  error
+
+	// Debug fields (protected by debugMu for thread safety)
+	debugMu         sync.Mutex
+	LastRequest     *http.Request
+	LastRequestBody string
+	LastResponse    *http.Response
+	LastRespBody    string
+}
+
+// NewClient creates a new Grape API client
+func NewClient(baseURL, clientID, clientSecret string) *Client {
+	// Normalize BaseURL to ensure it ends with a slash
+	// This prevents invalid URLs when concatenating endpoint paths
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL = baseURL + "/"
+	}
+
+	return &Client{
+		BaseURL:      baseURL,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		Debug: false,
+	}
+}
+
+// normalizeMac converts any MAC address format to lowercase without separators
+// Accepts formats: AA:BB:CC:DD:EE:FF, AA-BB-CC-DD-EE-FF, AABBCCDDEEFF, aabbccddeeff
+// Returns: aabbccddeeff
+func normalizeMac(mac string) string {
+	// Remove common separators: colons, hyphens, dots, spaces
+	re := regexp.MustCompile(`[:\-\.\s]`)
+	normalized := re.ReplaceAllString(mac, "")
+	// Convert to lowercase
+	return strings.ToLower(normalized)
+}

--- a/libs/grape/devices.go
+++ b/libs/grape/devices.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+package grape
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// getProvisioningServerID retrieves and caches the ProvisioningServer UUID
+// Uses sync.Once to prevent duplicate API calls under concurrent load
+func (c *Client) getProvisioningServerID() (string, error) {
+	c.provisioningServerIDOnce.Do(func() {
+		// Get settings to find ProvisioningServer UUID
+		settingsURL := c.BaseURL + "settings/"
+		settings, err := c.makeHawkRequest("GET", settingsURL, nil)
+		if err != nil {
+			c.provisioningServerIDErr = fmt.Errorf("failed to get settings: %w", err)
+			return
+		}
+
+		var settingsList []Setting
+		if err := json.Unmarshal(settings, &settingsList); err != nil {
+			c.provisioningServerIDErr = fmt.Errorf("failed to parse settings response: %w", err)
+			return
+		}
+
+		var settingProvisioningServerUUID string
+		for _, setting := range settingsList {
+			if setting.ParamName == "ProvisioningServer" {
+				settingProvisioningServerUUID = setting.UUID
+				break
+			}
+		}
+
+		if settingProvisioningServerUUID == "" {
+			c.provisioningServerIDErr = errors.New("ProvisioningServer setting not found in API response")
+			return
+		}
+
+		c.provisioningServerID = settingProvisioningServerUUID
+	})
+
+	return c.provisioningServerID, c.provisioningServerIDErr
+}
+
+// getEndpointsURL retrieves and caches the endpoints URL for device operations
+// Uses sync.Once to prevent duplicate API calls under concurrent load
+func (c *Client) getEndpointsURL() (string, error) {
+	c.endpointsURLOnce.Do(func() {
+		// Get company endpoints URL
+		tokenURL := c.BaseURL + "tokens/" + c.ClientID
+		tokenResp, err := c.makeHawkRequest("GET", tokenURL, nil)
+		if err != nil {
+			c.endpointsURLErr = fmt.Errorf("failed to get token info: %w", err)
+			return
+		}
+
+		var tokenData TokenResponse
+		if err := json.Unmarshal(tokenResp, &tokenData); err != nil {
+			c.endpointsURLErr = fmt.Errorf("failed to parse token response: %w", err)
+			return
+		}
+
+		companyResp, err := c.makeHawkRequest("GET", tokenData.Links.Company, nil)
+		if err != nil {
+			c.endpointsURLErr = fmt.Errorf("failed to get company info: %w", err)
+			return
+		}
+
+		var companyData CompanyResponse
+		if err := json.Unmarshal(companyResp, &companyData); err != nil {
+			c.endpointsURLErr = fmt.Errorf("failed to parse company response: %w", err)
+			return
+		}
+
+		c.endpointsURL = companyData.Links.Endpoints
+	})
+
+	return c.endpointsURL, c.endpointsURLErr
+}
+
+// RegisterDevice registers a device with the Grape provisioning server
+// mac: MAC address in any format (will be normalized)
+// provisioningURL: The URL of the provisioning server
+func (c *Client) RegisterDevice(mac, provisioningURL string) error {
+	// Normalize MAC address
+	normalizedMAC := normalizeMac(mac)
+
+	// Get ProvisioningServer UUID (cached)
+	settingProvisioningServerUUID, err := c.getProvisioningServerID()
+	if err != nil {
+		return err
+	}
+
+	// Get endpoints URL (cached)
+	endpointsURL, err := c.getEndpointsURL()
+	if err != nil {
+		return err
+	}
+
+	// Add device
+	deviceData := DeviceData{
+		MAC:                        normalizedMAC,
+		AutoprovisioningEnabled:    true,
+		WarrantyExpWarningPeriod:   nil,
+		SettingsManager: map[string]map[string]interface{}{
+			settingProvisioningServerUUID: {
+				"value": provisioningURL,
+				"attrs": map[string]string{"perm": "RW"},
+			},
+		},
+	}
+
+	deviceJSON, err := json.Marshal(deviceData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal device data: %w", err)
+	}
+
+	deviceURL := endpointsURL + normalizedMAC
+	_, err = c.makeHawkRequest("PUT", deviceURL, deviceJSON)
+	if err != nil {
+		return fmt.Errorf("failed to register device: %w", err)
+	}
+
+	return nil
+}

--- a/libs/grape/errors.go
+++ b/libs/grape/errors.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+package grape
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// APIError represents an error response from the Grape API
+type APIError struct {
+	StatusCode int
+	Status     string
+	Message    string
+	Body       string
+}
+
+// Error implements the error interface
+func (e APIError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("Grape API error (HTTP %d): %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("Grape API error (HTTP %d): %s", e.StatusCode, e.Status)
+}
+
+// parseErrorResponse attempts to extract error information from the response body
+func parseErrorResponse(statusCode int, status string, body []byte) error {
+	apiErr := APIError{
+		StatusCode: statusCode,
+		Status:     status,
+		Body:       string(body),
+	}
+
+	// Try to parse JSON error response
+	var errResp map[string]interface{}
+	if err := json.Unmarshal(body, &errResp); err == nil {
+		// Extract error message if available
+		if msg, ok := errResp["message"].(string); ok {
+			apiErr.Message = msg
+		} else if msg, ok := errResp["error"].(string); ok {
+			apiErr.Message = msg
+		} else if detail, ok := errResp["detail"].(string); ok {
+			apiErr.Message = detail
+		}
+	}
+
+	// If no message was extracted, use the raw body
+	if apiErr.Message == "" && len(body) > 0 {
+		apiErr.Message = string(body)
+	}
+
+	return apiErr
+}

--- a/libs/grape/types.go
+++ b/libs/grape/types.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+package grape
+
+// Setting represents a configuration setting in the Grape API
+type Setting struct {
+	UUID      string `json:"uuid"`
+	ParamName string `json:"param_name"`
+}
+
+// TokenResponse represents the response from the token endpoint
+type TokenResponse struct {
+	Links struct {
+		Company string `json:"company"`
+	} `json:"links"`
+}
+
+// CompanyResponse represents the response from the company endpoint
+type CompanyResponse struct {
+	Links struct {
+		Endpoints string `json:"endpoints"`
+	} `json:"links"`
+}
+
+// DeviceData represents the data structure for registering a device
+type DeviceData struct {
+	MAC                      string                            `json:"mac"`
+	AutoprovisioningEnabled  bool                              `json:"autoprovisioning_enabled"`
+	WarrantyExpWarningPeriod *int                              `json:"warranty_exp_warning_period"`
+	SettingsManager          map[string]map[string]interface{} `json:"settings_manager"`
+}

--- a/methods/providerDispatch.go
+++ b/methods/providerDispatch.go
@@ -126,6 +126,7 @@ func ProviderDispatch(c *gin.Context) {
 			Override:   "1",
 		}
 
+
 	case (provider == "ymcs") && !configuration.Config.Providers.Ymcs.Disable:
 		mac, url, err := parseParams(c)
 		if err != nil {
@@ -140,6 +141,20 @@ func ProviderDispatch(c *gin.Context) {
 			Url: redirectUrl,
 		}
 
+
+	case (provider == "grape") && !configuration.Config.Providers.Grape.Disable:
+		mac, url, err := parseParams(c)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		redirectUrl, _ := net_url.QueryUnescape(url)
+
+		device = providers.GrapeDevice{
+			Mac: mac.A0 + mac.A1 + mac.A2 + mac.A3 + mac.A4 + mac.A5,
+			Url: redirectUrl,
+		}
 	default:
 		c.JSON(http.StatusNotFound, gin.H{"error": "provider_not_supported"})
 		return

--- a/providers/grape.go
+++ b/providers/grape.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Falconieri project.
+ *
+ * Falconieri is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Falconieri is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Falconieri.  If not, see LICENSE.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+/*
+ * Grape provisioning provider
+ */
+package providers
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"sync"
+
+	"github.com/nethesis/falconieri/configuration"
+	"github.com/nethesis/falconieri/libs/grape"
+	"github.com/nethesis/falconieri/models"
+)
+
+var (
+	grapeClient     *grape.Client
+	grapeClientOnce sync.Once
+)
+
+// getGrapeClient returns a singleton Grape client instance.
+// This allows API navigation caching to work effectively across multiple requests.
+// The client is created using configuration loaded at startup.
+func getGrapeClient() *grape.Client {
+	grapeClientOnce.Do(func() {
+		grapeClient = grape.NewClient(
+			configuration.Config.Providers.Grape.BaseURL,
+			configuration.Config.Providers.Grape.ClientID,
+			configuration.Config.Providers.Grape.ClientSecret,
+		)
+	})
+	return grapeClient
+}
+
+type GrapeDevice struct {
+	Mac string
+	Url string
+}
+
+func (d GrapeDevice) Register() error {
+	client := getGrapeClient()
+
+	err := client.RegisterDevice(d.Mac, d.Url)
+	if err != nil {
+		// Check if this is an API error (4xx/5xx from server)
+		var apiErr grape.APIError
+		if errors.As(err, &apiErr) {
+			// Return API error directly so caller can inspect status/message
+			return apiErr
+		}
+
+		// Check if this is a transport-level error (DNS, connection, timeout)
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			return models.ProviderError{
+				Message:      "connection_to_remote_provider_failed",
+				WrappedError: err,
+			}
+		}
+
+		var netErr net.Error
+		if errors.As(err, &netErr) {
+			return models.ProviderError{
+				Message:      "connection_to_remote_provider_failed",
+				WrappedError: err,
+			}
+		}
+
+		// Other errors (JSON marshaling, etc.) - return as-is
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request adds support for the Gigaset Redirect and Provisioning Environment (GRAPE) as a new provider in the Falconieri project. It introduces a new Go client library for GRAPE, updates configuration structures and templates, and enhances documentation to reflect the new provider. The changes ensure that GRAPE can be configured similarly to the existing YMCS provider, including support for Hawk authentication.

**GRAPE provider integration:**

* Added a new GRAPE provider to the supported providers list and updated documentation in `README.md` to describe configuration parameters, environment variables, and provide example JSON configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R127) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R145-R151) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R184-R188)
* Updated Ansible deployment defaults and configuration templates to support GRAPE provider variables (`grape_base_url`, `grape_client_id`, etc.). [[1]](diffhunk://#diff-ba2ec758ce18eb87b77ad402cfad922b708f1c2993ca50f020b725fbe7a77441R30-R34) [[2]](diffhunk://#diff-f1a97ba5142886f1d862dacce4a35baefd6e3dd763b67ed914d3295821e738f2R33-R38)

**Configuration and code structure:**

* Refactored provider configuration structs in `configuration/config.go` to add `Grape` as a new provider and to distinguish between legacy and modern providers, updating environment variable parsing logic for GRAPE. [[1]](diffhunk://#diff-215e14fb1b8ba1b7d52981abc001a4b8c0619da07fdf2a581678bfcaa6304b40L32-R44) [[2]](diffhunk://#diff-215e14fb1b8ba1b7d52981abc001a4b8c0619da07fdf2a581678bfcaa6304b40L53-R58) [[3]](diffhunk://#diff-215e14fb1b8ba1b7d52981abc001a4b8c0619da07fdf2a581678bfcaa6304b40R224-R251)

**GRAPE client implementation:**

* Introduced a new Go package (`libs/grape/`) implementing the GRAPE API client, including support for Hawk authentication (`auth.go`), client initialization and MAC normalization (`client.go`), device registration logic (`devices.go`), error handling (`errors.go`), and API types (`types.go`). [[1]](diffhunk://#diff-a8802954c96e9dccd610bfef95b5004f6736506bf8989657b9c7dd77f921f363R1-R199) [[2]](diffhunk://#diff-ebf0ac8228abedd91002a35f532af2a425f799989ce8b05960ef613ea14c28bfR1-R75) [[3]](diffhunk://#diff-2bc20d57207b7861a7c2d06832fd1e236eb76a6cee91faecd0bf1a932bae7ab5R1-R157) [[4]](diffhunk://#diff-e1f62255587a1e60c7210f27b473099db38c2eb51e2946ba61ea98c175abf654R1-R73) [[5]](diffhunk://#diff-724de30d19b39348ef9a714058859fa057a12914196b90a0a7631e6597748719R1-R51)

These changes collectively enable Falconieri to provision devices using the Gigaset GRAPE API with secure authentication and configuration management.

https://github.com/NethServer/dev/issues/7764