### PR TITLE
feat: add SRAPS provisioning provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Supported providers:
 * [Yealink (legacy provider)](https://support-cdn.yealink.com/attachment/upload/attachment/2019-1-8/5/b6a08cc4-0d6c-4def-b2f4-224b9653c051/Yealink+XML+API+for+RPS-V1.6-ENG.pdf)
 * [YMCS (Yealink Management Cloud Service V4X)](https://support.yealink.com/document-detail/c0966bbacb51405397c55290c2925f65) To use the YMCS provider, you need to ask Yealink to enable `/v2/rps/addDevicesByMac` endpoint for your account.
 * [GRAPE (Gigaset Redirect and Provisioning Environment)](https://teamwork.gigaset.com/gigawiki/pages/viewpage.action?pageId=1535868981)
+* [SRAPS (Secure Redirection and Provisioning Service)](https://sraps.snom.com/documentation) - Snom provisioning platform, uses the same protocol as Grape
 
 ## APIs
 
@@ -118,11 +119,12 @@ Gigaset specific:
 
 * `disable_crc` If set to `true` Falconieri don't send the mac address's CRC code, default `false`
 
-YMCS and GRAPE specific:
+YMCS and GRAPE and SRAPS specific:
 
 * `base_url` API base URL, for example:
   * `https://eu-api.ymcs.yealink.com` for YMCS provider
   * `https://api.grape.gigaset.net/api/v1/` for GRAPE provider
+  * `https://api.sraps.snom.com/api/v1/` for SRAPS provider
 * `client_id` Client ID
 * `client_secret` Client secret/key
 
@@ -145,6 +147,12 @@ Example:
      },
      "grape": {
        "base_url": "https://api.grape.gigaset.net/api/v1/",
+       "client_id": "your-client-id",
+       "client_secret": "your-client-secret",
+       "disable": false
+     },
+     "sraps": {
+       "base_url": "https://api.sraps.snom.com/api/v1/",
        "client_id": "your-client-id",
        "client_secret": "your-client-secret",
        "disable": false
@@ -185,6 +193,11 @@ Example:
 * `GRAPE_CLIENT_ID` Hawk id issued by Gigaset for HMAC authentication
 * `GRAPE_CLIENT_SECRET` Hawk key issued by Gigaset for HMAC authentication
 * `GRAPE_DISABLE` Enable/Disable the GRAPE provider, default `false`
+
+* `SRAPS_BASE_URL` SRAPS API base URL, for example `https://api.sraps.snom.com/api/v1/`
+* `SRAPS_CLIENT_ID` Hawk id issued by Snom for HMAC authentication
+* `SRAPS_CLIENT_SECRET` Hawk key issued by Snom for HMAC authentication
+* `SRAPS_DISABLE` Enable/Disable the SRAPS provider, default `false`
 
 ## Other projects
 

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -56,6 +56,7 @@ type Configuration struct {
 		Yealink LegacyProviderConf `json:"yealink"`
 		Ymcs    ProviderConf       `json:"ymcs"`
 		Grape   ProviderConf       `json:"grape"`
+		Sraps   ProviderConf       `json:"sraps"`
 	} `json:"providers"`
 }
 
@@ -248,5 +249,34 @@ func Init(ConfigFilePtr *string) {
 			Config.Providers.Grape.BaseURL == "") {
 
 		Config.Providers.Grape.Disable = true
+	}
+
+	// SRAPS provider configuration
+	if os.Getenv("SRAPS_CLIENT_ID") != "" {
+		Config.Providers.Sraps.ClientID = os.Getenv("SRAPS_CLIENT_ID")
+	}
+
+	if os.Getenv("SRAPS_CLIENT_SECRET") != "" {
+		Config.Providers.Sraps.ClientSecret = os.Getenv("SRAPS_CLIENT_SECRET")
+	}
+
+	if os.Getenv("SRAPS_BASE_URL") != "" {
+		Config.Providers.Sraps.BaseURL = os.Getenv("SRAPS_BASE_URL")
+	}
+
+	if os.Getenv("SRAPS_DISABLE") != "" {
+
+		disable, err := strconv.ParseBool(os.Getenv("SRAPS_DISABLE"))
+		if err == nil {
+			Config.Providers.Sraps.Disable = disable
+		}
+	}
+
+	if !Config.Providers.Sraps.Disable &&
+		(Config.Providers.Sraps.ClientID == "" ||
+			Config.Providers.Sraps.ClientSecret == "" ||
+			Config.Providers.Sraps.BaseURL == "") {
+
+		Config.Providers.Sraps.Disable = true
 	}
 }

--- a/deploy/ansible/roles/falconieri/defaults/main.yml
+++ b/deploy/ansible/roles/falconieri/defaults/main.yml
@@ -32,3 +32,8 @@ grape_base_url: https://api.grape.gigaset.net/api/v1/
 grape_client_id: client
 grape_client_secret: secret
 grape_disable: "false"
+
+sraps_base_url: https://api.sraps.snom.com/api/v1/
+sraps_client_id: client
+sraps_client_secret: secret
+sraps_disable: "false"

--- a/deploy/ansible/roles/falconieri/templates/conf.json.tpl
+++ b/deploy/ansible/roles/falconieri/templates/conf.json.tpl
@@ -36,6 +36,12 @@
       "client_id": "{{ grape_client_id }}",
       "client_secret": "{{ grape_client_secret }}",
       "disable": {{ grape_disable }}
+    },
+    "sraps": {
+      "base_url": "{{ sraps_base_url }}",
+      "client_id": "{{ sraps_client_id }}",
+      "client_secret": "{{ sraps_client_secret }}",
+      "disable": {{ sraps_disable }}
     }
   }
 }

--- a/libs/grape/client.go
+++ b/libs/grape/client.go
@@ -38,6 +38,10 @@ type Client struct {
 	HTTPClient   *http.Client
 	Debug        bool
 
+	// ProvisioningSettingName is the param_name to search for in the settings list.
+	// Defaults to "ProvisioningServer" (Grape). SRAPS uses "setting_server".
+	ProvisioningSettingName string
+
 	// Cached API navigation data (thread-safe using sync.Once)
 	provisioningServerIDOnce sync.Once
 	provisioningServerID     string
@@ -64,9 +68,10 @@ func NewClient(baseURL, clientID, clientSecret string) *Client {
 	}
 
 	return &Client{
-		BaseURL:      baseURL,
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
+		BaseURL:                 baseURL,
+		ClientID:                clientID,
+		ClientSecret:            clientSecret,
+		ProvisioningSettingName: "ProvisioningServer",
 		HTTPClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},

--- a/libs/grape/devices.go
+++ b/libs/grape/devices.go
@@ -24,15 +24,16 @@ package grape
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
-// getProvisioningServerID retrieves and caches the ProvisioningServer UUID
-// Uses sync.Once to prevent duplicate API calls under concurrent load
+// getProvisioningServerID retrieves and caches the provisioning setting UUID.
+// The setting name is determined by c.ProvisioningSettingName (e.g.
+// "ProvisioningServer" for Grape, "setting_server" for SRAPS).
+// Uses sync.Once to prevent duplicate API calls under concurrent load.
 func (c *Client) getProvisioningServerID() (string, error) {
 	c.provisioningServerIDOnce.Do(func() {
-		// Get settings to find ProvisioningServer UUID
+		// Get settings to find the provisioning setting UUID
 		settingsURL := c.BaseURL + "settings/"
 		settings, err := c.makeHawkRequest("GET", settingsURL, nil)
 		if err != nil {
@@ -48,14 +49,14 @@ func (c *Client) getProvisioningServerID() (string, error) {
 
 		var settingProvisioningServerUUID string
 		for _, setting := range settingsList {
-			if setting.ParamName == "ProvisioningServer" {
+			if setting.ParamName == c.ProvisioningSettingName {
 				settingProvisioningServerUUID = setting.UUID
 				break
 			}
 		}
 
 		if settingProvisioningServerUUID == "" {
-			c.provisioningServerIDErr = errors.New("ProvisioningServer setting not found in API response")
+			c.provisioningServerIDErr = fmt.Errorf("%s setting not found in API response", c.ProvisioningSettingName)
 			return
 		}
 

--- a/methods/providerDispatch.go
+++ b/methods/providerDispatch.go
@@ -155,6 +155,20 @@ func ProviderDispatch(c *gin.Context) {
 			Mac: mac.A0 + mac.A1 + mac.A2 + mac.A3 + mac.A4 + mac.A5,
 			Url: redirectUrl,
 		}
+
+	case (provider == "sraps") && !configuration.Config.Providers.Sraps.Disable:
+		mac, url, err := parseParams(c)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		redirectUrl, _ := net_url.QueryUnescape(url)
+
+		device = providers.SrapsDevice{
+			Mac: mac.A0 + mac.A1 + mac.A2 + mac.A3 + mac.A4 + mac.A5,
+			Url: redirectUrl,
+		}
 	default:
 		c.JSON(http.StatusNotFound, gin.H{"error": "provider_not_supported"})
 		return

--- a/providers/sraps.go
+++ b/providers/sraps.go
@@ -21,7 +21,8 @@
  */
 
 /*
- * GRAPE provisioning provider
+ * SRAPS (Secure Redirection and Provisioning Service) provider
+ * Reuses the grape library with a different base URL
  */
 package providers
 
@@ -37,35 +38,35 @@ import (
 )
 
 var (
-	grapeClient     *grape.Client
-	grapeClientOnce sync.Once
+	srapsClient     *grape.Client
+	srapsClientOnce sync.Once
 )
 
-// getGrapeClient returns a singleton GRAPE client instance.
-// This allows API navigation caching to work effectively across multiple requests.
-// The client is created using configuration loaded at startup.
-func getGrapeClient() *grape.Client {
-	grapeClientOnce.Do(func() {
-		grapeClient = grape.NewClient(
-			configuration.Config.Providers.Grape.BaseURL,
-			configuration.Config.Providers.Grape.ClientID,
-			configuration.Config.Providers.Grape.ClientSecret,
+// getSrapsClient returns a singleton SRAPS client instance.
+// SRAPS uses the same protocol as Grape but with a different base URL
+// and uses "setting_server" instead of "ProvisioningServer" for the setting name.
+func getSrapsClient() *grape.Client {
+	srapsClientOnce.Do(func() {
+		srapsClient = grape.NewClient(
+			configuration.Config.Providers.Sraps.BaseURL,
+			configuration.Config.Providers.Sraps.ClientID,
+			configuration.Config.Providers.Sraps.ClientSecret,
 		)
+		srapsClient.ProvisioningSettingName = "setting_server"
 	})
-	return grapeClient
+	return srapsClient
 }
 
-type GrapeDevice struct {
+type SrapsDevice struct {
 	Mac string
 	Url string
 }
 
-func (d GrapeDevice) Register() error {
-	client := getGrapeClient()
+func (d SrapsDevice) Register() error {
+	client := getSrapsClient()
 
 	err := client.RegisterDevice(d.Mac, d.Url)
 	if err != nil {
-		// Check if this is an API error (4xx/5xx from server)
 		var apiErr grape.APIError
 		if errors.As(err, &apiErr) {
 			return models.ProviderError{
@@ -74,7 +75,6 @@ func (d GrapeDevice) Register() error {
 			}
 		}
 
-		// Check if this is a transport-level error (DNS, connection, timeout)
 		var urlErr *url.Error
 		if errors.As(err, &urlErr) {
 			return models.ProviderError{
@@ -91,7 +91,6 @@ func (d GrapeDevice) Register() error {
 			}
 		}
 
-		// Other errors (JSON marshaling, etc.) - return as-is
 		return err
 	}
 


### PR DESCRIPTION
## Overview

This PR adds support for the SRAPS (Secure Redirection and Provisioning Service) provider, a Snom-based provisioning platform that uses the same protocol as the existing Grape provider but with different API details.

## Changes

### Architecture
- **Reuses Grape library**: SRAPS shares the Hawk authentication protocol and overall structure with Grape
- **Different base URL**: https://api.sraps.snom.com/api/v1/ (vs Grape's https://api.grape.gigaset.net/api/v1/)
- **Different setting name**: Uses `setting_server` instead of `ProvisioningServer` for device provisioning

### Implementation Details

1. **Grape client enhancements** (refactor)
   - Made ProvisioningSettingName configurable in the Client struct
   - Defaults to 'ProvisioningServer' for backward compatibility with Grape

2. **Provider implementation**
   - New `providers/sraps.go` module following the same pattern as Grape
   - Singleton client management with `sync.Once` for thread safety
   - Proper error handling and API error propagation

3. **Configuration support**
   - Added SRAPS config struct to configuration.go
   - Environment variable support: `SRAPS_BASE_URL`, `SRAPS_CLIENT_ID`, `SRAPS_CLIENT_SECRET`, `SRAPS_DISABLE`
   - Auto-disable if credentials are missing

4. **Router integration**
   - Added case for `sraps` provider in the dispatcher
   - Follows the same MAC address normalization as Grape

5. **Documentation & Deployment**
   - Updated README with SRAPS provider info
   - Ansible playbook support (defaults and template)
