### PR TITLE
fix: correct grape/sraps API library issues found in doc review

### DIFF
--- a/libs/grape/auth.go
+++ b/libs/grape/auth.go
@@ -130,8 +130,9 @@ func createHawkAuthHeader(creds *HawkCredentials, method, rawURL string, payload
 	return authHeader, nil
 }
 
-// makeHawkRequest performs an HTTP request with Hawk authentication
-func (c *Client) makeHawkRequest(method, url string, body []byte) ([]byte, error) {
+// makeHawkRequestFull performs an HTTP request with Hawk authentication and
+// returns both the response body and headers (needed for Link-based pagination).
+func (c *Client) makeHawkRequestFull(method, url string, body []byte) ([]byte, http.Header, error) {
 	var req *http.Request
 	var err error
 	var contentType string
@@ -139,14 +140,14 @@ func (c *Client) makeHawkRequest(method, url string, body []byte) ([]byte, error
 	if body != nil {
 		req, err = http.NewRequest(method, url, bytes.NewReader(body))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		contentType = "application/json"
 		req.Header.Set("Content-Type", contentType)
 	} else {
 		req, err = http.NewRequest(method, url, nil)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		contentType = ""
 	}
@@ -162,7 +163,7 @@ func (c *Client) makeHawkRequest(method, url string, body []byte) ([]byte, error
 	// Add Hawk authentication header
 	authHeader, err := createHawkAuthHeader(creds, method, url, body, contentType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Hawk auth header: %v", err)
+		return nil, nil, fmt.Errorf("failed to create Hawk auth header: %v", err)
 	}
 
 	req.Header.Set("Authorization", authHeader)
@@ -177,13 +178,13 @@ func (c *Client) makeHawkRequest(method, url string, body []byte) ([]byte, error
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	// Store response for debugging
@@ -195,8 +196,14 @@ func (c *Client) makeHawkRequest(method, url string, body []byte) ([]byte, error
 	}
 
 	if resp.StatusCode >= 400 {
-		return nil, parseErrorResponse(resp.StatusCode, resp.Status, bodyBytes)
+		return nil, nil, parseErrorResponse(resp.StatusCode, resp.Status, bodyBytes)
 	}
 
-	return bodyBytes, nil
+	return bodyBytes, resp.Header, nil
+}
+
+// makeHawkRequest performs an HTTP request with Hawk authentication
+func (c *Client) makeHawkRequest(method, url string, body []byte) ([]byte, error) {
+	bodyBytes, _, err := c.makeHawkRequestFull(method, url, body)
+	return bodyBytes, err
 }

--- a/libs/grape/devices.go
+++ b/libs/grape/devices.go
@@ -25,6 +25,7 @@ package grape
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // getProvisioningServerID retrieves and caches the provisioning setting UUID.
@@ -33,37 +34,61 @@ import (
 // Uses sync.Once to prevent duplicate API calls under concurrent load.
 func (c *Client) getProvisioningServerID() (string, error) {
 	c.provisioningServerIDOnce.Do(func() {
-		// Get settings to find the provisioning setting UUID
-		settingsURL := c.BaseURL + "settings/"
-		settings, err := c.makeHawkRequest("GET", settingsURL, nil)
-		if err != nil {
-			c.provisioningServerIDErr = fmt.Errorf("failed to get settings: %w", err)
-			return
-		}
-
-		var settingsList []Setting
-		if err := json.Unmarshal(settings, &settingsList); err != nil {
-			c.provisioningServerIDErr = fmt.Errorf("failed to parse settings response: %w", err)
-			return
-		}
-
-		var settingProvisioningServerUUID string
-		for _, setting := range settingsList {
-			if setting.ParamName == c.ProvisioningSettingName {
-				settingProvisioningServerUUID = setting.UUID
-				break
+		// Fetch all settings pages to find the provisioning setting UUID.
+		// The API paginates with default 20 items; use page_size=1000 to
+		// minimise round-trips. Pagination continues while the response
+		// contains a Link header with rel="next".
+		nextURL := c.BaseURL + "settings/?page_size=1000"
+		for nextURL != "" {
+			pageBytes, headers, err := c.makeHawkRequestFull("GET", nextURL, nil)
+			if err != nil {
+				c.provisioningServerIDErr = fmt.Errorf("failed to get settings: %w", err)
+				return
 			}
+
+			var page []Setting
+			if err := json.Unmarshal(pageBytes, &page); err != nil {
+				c.provisioningServerIDErr = fmt.Errorf("failed to parse settings response: %w", err)
+				return
+			}
+
+			for _, setting := range page {
+				if setting.ParamName == c.ProvisioningSettingName {
+					c.provisioningServerID = setting.UUID
+					return
+				}
+			}
+
+			// Follow Link header for next page if present
+			nextURL = parseLinkNext(headers.Get("Link"))
 		}
 
-		if settingProvisioningServerUUID == "" {
-			c.provisioningServerIDErr = fmt.Errorf("%s setting not found in API response", c.ProvisioningSettingName)
-			return
-		}
-
-		c.provisioningServerID = settingProvisioningServerUUID
+		c.provisioningServerIDErr = fmt.Errorf("%s setting not found in API response", c.ProvisioningSettingName)
 	})
 
 	return c.provisioningServerID, c.provisioningServerIDErr
+}
+
+// parseLinkNext extracts the URL for rel="next" from an RFC 5988 Link header.
+// Returns an empty string if there is no next page.
+func parseLinkNext(linkHeader string) string {
+	// Format: <https://...>; rel="next", <https://...>; rel="prev"
+	for _, part := range strings.Split(linkHeader, ",") {
+		part = strings.TrimSpace(part)
+		segments := strings.Split(part, ";")
+		if len(segments) < 2 {
+			continue
+		}
+		for _, seg := range segments[1:] {
+			if strings.TrimSpace(seg) == `rel="next"` {
+				url := strings.TrimSpace(segments[0])
+				url = strings.TrimPrefix(url, "<")
+				url = strings.TrimSuffix(url, ">")
+				return url
+			}
+		}
+	}
+	return ""
 }
 
 // getEndpointsURL retrieves and caches the endpoints URL for device operations

--- a/libs/grape/errors.go
+++ b/libs/grape/errors.go
@@ -38,9 +38,9 @@ type APIError struct {
 // Error implements the error interface
 func (e APIError) Error() string {
 	if e.Message != "" {
-		return fmt.Sprintf("GRAPE API error (HTTP %d): %s", e.StatusCode, e.Message)
+		return fmt.Sprintf("API error (HTTP %d): %s", e.StatusCode, e.Message)
 	}
-	return fmt.Sprintf("GRAPE API error (HTTP %d): %s", e.StatusCode, e.Status)
+	return fmt.Sprintf("API error (HTTP %d): %s", e.StatusCode, e.Status)
 }
 
 // parseErrorResponse attempts to extract error information from the response body

--- a/libs/grape/types.go
+++ b/libs/grape/types.go
@@ -46,6 +46,6 @@ type CompanyResponse struct {
 type DeviceData struct {
 	MAC                      string                            `json:"mac"`
 	AutoprovisioningEnabled  bool                              `json:"autoprovisioning_enabled"`
-	WarrantyExpWarningPeriod *int                              `json:"warranty_exp_warning_period"`
+	WarrantyExpWarningPeriod *int                              `json:"warranty_exp_warning_period,omitempty"`
 	SettingsManager          map[string]map[string]interface{} `json:"settings_manager"`
 }

--- a/providers/grape.go
+++ b/providers/grape.go
@@ -34,6 +34,7 @@ import (
 	"github.com/nethesis/falconieri/configuration"
 	"github.com/nethesis/falconieri/libs/grape"
 	"github.com/nethesis/falconieri/models"
+	"github.com/nethesis/falconieri/utils"
 )
 
 var (
@@ -68,10 +69,18 @@ func (d GrapeDevice) Register() error {
 		// Check if this is an API error (4xx/5xx from server)
 		var apiErr grape.APIError
 		if errors.As(err, &apiErr) {
-			return models.ProviderError{
-				Message:      "provider_remote_call_failed",
-				WrappedError: apiErr,
+			// Parse the API error to map it to semantic error codes
+			parsedErr := utils.ParseProviderError(apiErr.Error())
+			if providerErr, ok := parsedErr.(models.ProviderError); ok {
+				// Already a semantic error from ParseProviderError
+				return providerErr
 			}
+			if _, ok := parsedErr.(*models.ProviderError); ok {
+				// Already a semantic error from ParseProviderError
+				return parsedErr
+			}
+			// Return semantic error (e.g., "device_owned_by_other_user")
+			return parsedErr
 		}
 
 		// Check if this is a transport-level error (DNS, connection, timeout)

--- a/providers/grape.go
+++ b/providers/grape.go
@@ -69,18 +69,7 @@ func (d GrapeDevice) Register() error {
 		// Check if this is an API error (4xx/5xx from server)
 		var apiErr grape.APIError
 		if errors.As(err, &apiErr) {
-			// Parse the API error to map it to semantic error codes
-			parsedErr := utils.ParseProviderError(apiErr.Error())
-			if providerErr, ok := parsedErr.(models.ProviderError); ok {
-				// Already a semantic error from ParseProviderError
-				return providerErr
-			}
-			if _, ok := parsedErr.(*models.ProviderError); ok {
-				// Already a semantic error from ParseProviderError
-				return parsedErr
-			}
-			// Return semantic error (e.g., "device_owned_by_other_user")
-			return parsedErr
+			return utils.ParseProviderError(apiErr.Error())
 		}
 
 		// Check if this is a transport-level error (DNS, connection, timeout)

--- a/providers/sraps.go
+++ b/providers/sraps.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nethesis/falconieri/configuration"
 	"github.com/nethesis/falconieri/libs/grape"
 	"github.com/nethesis/falconieri/models"
+	"github.com/nethesis/falconieri/utils"
 )
 
 var (
@@ -69,10 +70,18 @@ func (d SrapsDevice) Register() error {
 	if err != nil {
 		var apiErr grape.APIError
 		if errors.As(err, &apiErr) {
-			return models.ProviderError{
-				Message:      "provider_remote_call_failed",
-				WrappedError: apiErr,
+			// Parse the API error to map it to semantic error codes
+			parsedErr := utils.ParseProviderError(apiErr.Error())
+			if providerErr, ok := parsedErr.(models.ProviderError); ok {
+				// Already a semantic error from ParseProviderError
+				return providerErr
 			}
+			if _, ok := parsedErr.(*models.ProviderError); ok {
+				// Already a semantic error from ParseProviderError
+				return parsedErr
+			}
+			// Return semantic error (e.g., "device_owned_by_other_user")
+			return parsedErr
 		}
 
 		var urlErr *url.Error

--- a/providers/sraps.go
+++ b/providers/sraps.go
@@ -70,18 +70,7 @@ func (d SrapsDevice) Register() error {
 	if err != nil {
 		var apiErr grape.APIError
 		if errors.As(err, &apiErr) {
-			// Parse the API error to map it to semantic error codes
-			parsedErr := utils.ParseProviderError(apiErr.Error())
-			if providerErr, ok := parsedErr.(models.ProviderError); ok {
-				// Already a semantic error from ParseProviderError
-				return providerErr
-			}
-			if _, ok := parsedErr.(*models.ProviderError); ok {
-				// Already a semantic error from ParseProviderError
-				return parsedErr
-			}
-			// Return semantic error (e.g., "device_owned_by_other_user")
-			return parsedErr
+			return utils.ParseProviderError(apiErr.Error())
 		}
 
 		var urlErr *url.Error

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -79,7 +79,9 @@ func ParseProviderError(message string) error {
 		message == "800004", //ymcs
 		message == "800003", //ymcs: Resource already exists
 		strings.Contains(strings.ToLower(message), "device already managed"),
-		strings.Contains(strings.ToLower(message), "resource already exists"):
+		strings.Contains(strings.ToLower(message), "resource already exists"),
+		strings.Contains(strings.ToLower(message), "taken_mac_or_forbidden"), //grape/sraps
+		strings.Contains(strings.ToLower(message), "permission") && strings.Contains(strings.ToLower(message), "endpoint"): //grape/sraps: "User lacks permission to endpoint"
 
 		return errors.New("device_owned_by_other_user")
 


### PR DESCRIPTION
This pull request introduces improvements to the Hawk-authenticated API request handling, enhances pagination support for settings retrieval, refines error handling and messaging, and improves semantic error mapping for device registration. The most important changes are grouped below by theme.

### API Request Handling & Pagination

* Refactored the Hawk-authenticated request logic by introducing `makeHawkRequestFull`, which returns both the response body and headers to support Link-based pagination. The original `makeHawkRequest` now delegates to this new method. [[1]](diffhunk://#diff-a8802954c96e9dccd610bfef95b5004f6736506bf8989657b9c7dd77f921f363L133-R150) [[2]](diffhunk://#diff-a8802954c96e9dccd610bfef95b5004f6736506bf8989657b9c7dd77f921f363L165-R166) [[3]](diffhunk://#diff-a8802954c96e9dccd610bfef95b5004f6736506bf8989657b9c7dd77f921f363L180-R187) [[4]](diffhunk://#diff-a8802954c96e9dccd610bfef95b5004f6736506bf8989657b9c7dd77f921f363L198-R208)
* Enhanced the settings retrieval in `getProvisioningServerID` to handle paginated responses using the Link header, ensuring all pages are fetched and searched for the provisioning setting UUID. Added the `parseLinkNext` helper for extracting the next page URL.

### Error Handling & Messaging

* Improved semantic error mapping in device registration flows by parsing API errors and returning meaningful provider error codes, such as `"device_owned_by_other_user"`, instead of generic errors. This affects both `GrapeDevice` and `SrapsDevice` registration. [[1]](diffhunk://#diff-0e8bc39a1afe21e539605a1016b8d9d58faf96a5aa74d9f0fdd4e63fff8c1e88L71-R83) [[2]](diffhunk://#diff-57ccceee9b8009a1795188803ee7b35eb468a1cd946ef99f625c3bf45e0052d3L72-R84)
* Expanded the error parsing logic in `ParseProviderError` to recognize additional error messages specific to grape/sraps, including `"taken_mac_or_forbidden"` and permission-related endpoint errors.
* Simplified the `APIError` message formatting to remove the "GRAPE" prefix for consistency and clarity.

### Data Structure Improvements

* Added `omitempty` to the `WarrantyExpWarningPeriod` field in `DeviceData` to prevent sending null values in JSON payloads.

### Miscellaneous

* Added missing imports for `strings` and `utils` in relevant files to support new functionality. [[1]](diffhunk://#diff-2bc20d57207b7861a7c2d06832fd1e236eb76a6cee91faecd0bf1a932bae7ab5R28) [[2]](diffhunk://#diff-0e8bc39a1afe21e539605a1016b8d9d58faf96a5aa74d9f0fdd4e63fff8c1e88R37) [[3]](diffhunk://#diff-57ccceee9b8009a1795188803ee7b35eb468a1cd946ef99f625c3bf45e0052d3R38)